### PR TITLE
Refactor config parsing and add ./config to config hierarchy

### DIFF
--- a/src/joshuto/config.rs
+++ b/src/joshuto/config.rs
@@ -8,3 +8,36 @@ pub use self::keymap::JoshutoKeymap;
 pub use self::mimetype::JoshutoMimetype;
 pub use self::theme::JoshutoTheme;
 pub use self::theme::JoshutoColorTheme;
+
+pub fn search_config_hierarchy(filename: &str) -> Option<std::path::PathBuf> {
+    match xdg::BaseDirectories::with_prefix(::PROGRAM_NAME) {
+        Ok(dirs) => {
+            dirs
+                // 1st priority is $XDG_CONFIG_HOME
+                .find_config_file(filename)
+                // 2nd priority is ./config
+                .or_else(|| {
+                    let default_config = std::path::Path::new("./config").join(filename);
+                    match default_config.exists() {
+                        true => Some(default_config),
+                        false => None,
+                    }
+                })
+        },
+        Err(e) => {
+            eprintln!("{}", e);
+            None
+        },
+    }
+}
+
+fn read_config(filename: &str) -> Option<String> {
+    let config_path = search_config_hierarchy(filename)?;
+    match std::fs::read_to_string(&config_path) {
+        Ok(content) => Some(content),
+        Err(e) => {
+            eprintln!("{}", e);
+            std::process::exit(1)
+        },
+    }
+}

--- a/src/joshuto/config.rs
+++ b/src/joshuto/config.rs
@@ -1,3 +1,7 @@
+extern crate serde;
+
+use self::serde::de::DeserializeOwned;
+
 pub mod config;
 pub mod keymap;
 pub mod mimetype;
@@ -40,4 +44,22 @@ fn read_config(filename: &str) -> Option<String> {
             std::process::exit(1)
         },
     }
+}
+
+trait Flattenable<T> {
+    fn flatten(self) -> T;
+}
+
+fn parse_config<T, S>(filename: &str) -> Option<S>
+    where T: DeserializeOwned + Flattenable<S>
+{
+    let config_contents = read_config(filename)?;
+    let config = match toml::from_str::<T>(&config_contents) {
+        Ok(config) => config,
+        Err(e) => {
+            eprintln!("Error parsing {} file: {}", filename, e);
+            std::process::exit(1);
+        },
+    };
+    Some(config.flatten())
 }

--- a/src/joshuto/config/config.rs
+++ b/src/joshuto/config/config.rs
@@ -2,7 +2,6 @@ extern crate whoami;
 extern crate toml;
 extern crate xdg;
 
-use std::fs;
 use std::process;
 
 use joshuto;
@@ -117,32 +116,15 @@ impl JoshutoConfig {
         }
     }
 
-    fn read_config() -> Option<JoshutoRawConfig>
-    {
-        match xdg::BaseDirectories::with_profile(::PROGRAM_NAME, "") {
-            Ok(dirs) => {
-                let config_path = dirs.find_config_file(::CONFIG_FILE)?;
-                match fs::read_to_string(&config_path) {
-                    Ok(config_contents) => {
-                        match toml::from_str(&config_contents) {
-                            Ok(config) => {
-                                Some(config)
-                            },
-                            Err(e) => {
-                                eprintln!("Error parsing keymap file: {}", e);
-                                process::exit(1);
-                            },
-                        }
-                    },
-                    Err(e) => {
-                        eprintln!("{}", e);
-                        None
-                    },
-                }
+    fn read_config() -> Option<JoshutoRawConfig> {
+        let config_contents = crate::joshuto::config::read_config(::CONFIG_FILE)?;
+        match toml::from_str(&config_contents) {
+            Ok(config) => {
+                Some(config)
             },
             Err(e) => {
-                eprintln!("{}", e);
-                None
+                eprintln!("Error parsing config file: {}", e);
+                process::exit(1);
             },
         }
     }

--- a/src/joshuto/config/config.rs
+++ b/src/joshuto/config/config.rs
@@ -2,10 +2,9 @@ extern crate whoami;
 extern crate toml;
 extern crate xdg;
 
-use std::process;
-
 use joshuto;
 use joshuto::sort;
+use joshuto::config::{Flattenable, parse_config};
 
 #[derive(Clone, Debug, Deserialize)]
 pub struct SortRawOption {
@@ -34,8 +33,10 @@ impl JoshutoRawConfig {
             column_ratio: Some([1, 3, 4]),
         }
     }
+}
 
-    pub fn flatten(self) -> JoshutoConfig
+impl Flattenable<JoshutoConfig> for JoshutoRawConfig {
+    fn flatten(self) -> JoshutoConfig
     {
         let column_ratio = match self.column_ratio {
             Some(s) => (s[0], s[1], s[2]),
@@ -116,28 +117,8 @@ impl JoshutoConfig {
         }
     }
 
-    fn read_config() -> Option<JoshutoRawConfig> {
-        let config_contents = crate::joshuto::config::read_config(::CONFIG_FILE)?;
-        match toml::from_str(&config_contents) {
-            Ok(config) => {
-                Some(config)
-            },
-            Err(e) => {
-                eprintln!("Error parsing config file: {}", e);
-                process::exit(1);
-            },
-        }
-    }
-
-    pub fn get_config() -> Self
-    {
-        match Self::read_config() {
-            Some(config) => {
-                config.flatten()
-            }
-            None => {
-                JoshutoConfig::new()
-            }
-        }
+    pub fn get_config() -> JoshutoConfig {
+        parse_config::<JoshutoRawConfig, JoshutoConfig>(::CONFIG_FILE)
+            .unwrap_or_else(|| JoshutoConfig::new())
     }
 }

--- a/src/joshuto/config/keymap.rs
+++ b/src/joshuto/config/keymap.rs
@@ -3,7 +3,6 @@ extern crate toml;
 extern crate xdg;
 
 use std::collections::HashMap;
-use std::fs;
 use std::process;
 
 use joshuto::command;
@@ -65,32 +64,15 @@ impl JoshutoKeymap {
         }
     }
 
-    fn read_config() -> Option<JoshutoRawKeymap>
-    {
-        match xdg::BaseDirectories::with_profile(::PROGRAM_NAME, "") {
-            Ok(dirs) => {
-                let config_path = dirs.find_config_file(::KEYMAP_FILE)?;
-                match fs::read_to_string(&config_path) {
-                    Ok(config_contents) => {
-                        match toml::from_str(&config_contents) {
-                            Ok(config) => {
-                                Some(config)
-                            },
-                            Err(e) => {
-                                eprintln!("Error parsing keymap file: {}", e);
-                                process::exit(1);
-                            },
-                        }
-                    },
-                    Err(e) => {
-                        eprintln!("{}", e);
-                        process::exit(1);
-                    },
-                }
+    fn read_config() -> Option<JoshutoRawKeymap> {
+        let config_contents = crate::joshuto::config::read_config(::KEYMAP_FILE)?;
+        match toml::from_str(&config_contents) {
+            Ok(config) => {
+                Some(config)
             },
             Err(e) => {
-                eprintln!("{}", e);
-                None
+                eprintln!("Error parsing keymap file: {}", e);
+                process::exit(1);
             },
         }
     }

--- a/src/joshuto/config/mimetype.rs
+++ b/src/joshuto/config/mimetype.rs
@@ -3,7 +3,8 @@ extern crate xdg;
 
 use std::fmt;
 use std::collections::HashMap;
-use std::process;
+
+use joshuto::config::{Flattenable, parse_config};
 
 #[derive(Debug, Deserialize)]
 pub struct JoshutoMimetypeEntry {
@@ -52,8 +53,10 @@ impl JoshutoRawMimetype {
             extensions: None,
         }
     }
+}
 
-    pub fn flatten(self) -> JoshutoMimetype
+impl Flattenable<JoshutoMimetype> for JoshutoRawMimetype {
+    fn flatten(self) -> JoshutoMimetype
     {
         let mimetypes = self.mimetypes.unwrap_or(HashMap::new());
         let extensions = self.extensions.unwrap_or(HashMap::new());
@@ -81,28 +84,8 @@ impl JoshutoMimetype {
         }
     }
 
-    fn read_config() -> Option<JoshutoRawMimetype> {
-        let config_contents = crate::joshuto::config::read_config(::MIMETYPE_FILE)?;
-        match toml::from_str(&config_contents) {
-            Ok(config) => {
-                Some(config)
-            },
-            Err(e) => {
-                eprintln!("Error parsing mimetype file: {}", e);
-                process::exit(1);
-            },
-        }
-    }
-
-    pub fn get_config() -> Self
-    {
-        match Self::read_config() {
-            Some(config) => {
-                config.flatten()
-            }
-            None => {
-                Self::new()
-            }
-        }
+    pub fn get_config() -> JoshutoMimetype {
+        parse_config::<JoshutoRawMimetype, JoshutoMimetype>(::MIMETYPE_FILE)
+            .unwrap_or_else(|| JoshutoMimetype::new())
     }
 }

--- a/src/joshuto/config/mimetype.rs
+++ b/src/joshuto/config/mimetype.rs
@@ -2,7 +2,6 @@ extern crate toml;
 extern crate xdg;
 
 use std::fmt;
-use std::fs;
 use std::collections::HashMap;
 use std::process;
 
@@ -82,32 +81,15 @@ impl JoshutoMimetype {
         }
     }
 
-    fn read_config() -> Option<JoshutoRawMimetype>
-    {
-        match xdg::BaseDirectories::with_profile(::PROGRAM_NAME, "") {
-            Ok(dirs) => {
-                let config_path = dirs.find_config_file(::MIMETYPE_FILE)?;
-                match fs::read_to_string(&config_path) {
-                    Ok(config_contents) => {
-                        match toml::from_str(&config_contents) {
-                            Ok(config) => {
-                                Some(config)
-                            },
-                            Err(e) => {
-                                eprintln!("Error parsing mimetype file: {}", e);
-                                process::exit(1);
-                            },
-                        }
-                    },
-                    Err(e) => {
-                        eprintln!("{}", e);
-                        None
-                    },
-                }
+    fn read_config() -> Option<JoshutoRawMimetype> {
+        let config_contents = crate::joshuto::config::read_config(::MIMETYPE_FILE)?;
+        match toml::from_str(&config_contents) {
+            Ok(config) => {
+                Some(config)
             },
             Err(e) => {
-                eprintln!("{}", e);
-                None
+                eprintln!("Error parsing mimetype file: {}", e);
+                process::exit(1);
             },
         }
     }

--- a/src/joshuto/config/theme.rs
+++ b/src/joshuto/config/theme.rs
@@ -2,7 +2,6 @@ extern crate toml;
 extern crate xdg;
 
 use std::collections::HashMap;
-use std::fs;
 use std::process;
 
 #[derive(Debug, Deserialize, Clone)]
@@ -232,32 +231,15 @@ impl JoshutoTheme {
 
     }
 
-    fn read_config() -> Option<JoshutoRawTheme>
-    {
-        match xdg::BaseDirectories::with_profile(::PROGRAM_NAME, "") {
-            Ok(dirs) => {
-                let config_path = dirs.find_config_file(::THEME_FILE)?;
-                match fs::read_to_string(&config_path) {
-                    Ok(config_contents) => {
-                        match toml::from_str(&config_contents) {
-                            Ok(config) => {
-                                Some(config)
-                            },
-                            Err(e) => {
-                                eprintln!("Error parsing theme file: {}", e);
-                                process::exit(1);
-                            },
-                        }
-                    },
-                    Err(e) => {
-                        eprintln!("{}", e);
-                        None
-                    },
-                }
+    fn read_config() -> Option<JoshutoRawTheme> {
+        let config_contents = crate::joshuto::config::read_config(::THEME_FILE)?;
+        match toml::from_str(&config_contents) {
+            Ok(config) => {
+                Some(config)
             },
             Err(e) => {
-                eprintln!("{}", e);
-                None
+                eprintln!("Error parsing theme file: {}", e);
+                process::exit(1);
             },
         }
     }

--- a/src/joshuto/config/theme.rs
+++ b/src/joshuto/config/theme.rs
@@ -2,7 +2,8 @@ extern crate toml;
 extern crate xdg;
 
 use std::collections::HashMap;
-use std::process;
+
+use joshuto::config::{Flattenable, parse_config};
 
 #[derive(Debug, Deserialize, Clone)]
 pub struct JoshutoColorPair {
@@ -56,8 +57,8 @@ pub struct JoshutoRawTheme {
     ext: Option<HashMap<String, JoshutoRawColorTheme>>,
 }
 
-impl JoshutoRawTheme {
-    pub fn flatten(self) -> JoshutoTheme
+impl Flattenable<JoshutoTheme> for JoshutoRawTheme {
+    fn flatten(self) -> JoshutoTheme
     {
         let colorpair = match self.colorpair {
                 Some(s) => s,
@@ -231,28 +232,8 @@ impl JoshutoTheme {
 
     }
 
-    fn read_config() -> Option<JoshutoRawTheme> {
-        let config_contents = crate::joshuto::config::read_config(::THEME_FILE)?;
-        match toml::from_str(&config_contents) {
-            Ok(config) => {
-                Some(config)
-            },
-            Err(e) => {
-                eprintln!("Error parsing theme file: {}", e);
-                process::exit(1);
-            },
-        }
-    }
-
-    pub fn get_config() -> Self
-    {
-        match Self::read_config() {
-            Some(config) => {
-                config.flatten()
-            }
-            None => {
-                Self::new()
-            }
-        }
+    pub fn get_config() -> JoshutoTheme {
+        parse_config::<JoshutoRawTheme, JoshutoTheme>(::THEME_FILE)
+            .unwrap_or_else(|| JoshutoTheme::new())
     }
 }


### PR DESCRIPTION
So currently joshuto doesn't work unless the config files are copied from `./config` to `~/.config/joshuto`, since no keybinds are enabled. This PR loads default config files from `./config` if there isn't one in `~/.config/joshuto/`. I also refactored out the `read_config` function from all the config parsing files in the process.

edit: This also adds the `search_config_hiearchy` function, which can be expanded in the future if other config file locations are desired.