### PR TITLE
Change mime-detective source repository temporarily for arch-linux fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ fs_extra = "1.1.0"
 lazy_static = "1.2.0"
 libc = "0.2.46"
 mime = "0.3.13"
-mime-detective = "0.2.1"
+mime-detective = { git = "https://github.com/cjbassi/mime-detective", branch = "arch-linux" }
 open = "1.2.2"
 serde = "1.0.84"
 serde_derive = "1.0.84"


### PR DESCRIPTION
mime-detective currently doesn't work on Arch Linux because the 'magic' file location that mime-detective expects is different on Arch Linux. I fixed the issue and created a PR for this change at csharad/mime-detective#2 but I'm still waiting for merge