### PR TITLE
[WIP] Replace delete_files command with trash_files

### DIFF
--- a/config/keymap.toml
+++ b/config/keymap.toml
@@ -118,11 +118,11 @@ args = [ "overwrite" ]
 
 [[mapcommand]]
 keys = [ "d", "D" ]
-command = "delete_files"
+command = "trash_files"
 
 [[mapcommand]]
 keys = [ "Delete" ]
-command = "delete_files"
+command = "trash_files"
 
 
 [[mapcommand]]

--- a/src/joshuto/command.rs
+++ b/src/joshuto/command.rs
@@ -35,8 +35,8 @@ pub use self::file_operation::CutFiles;
 pub use self::file_operation::CopyFiles;
 pub use self::file_operation::PasteFiles;
 
-mod delete_file;
-pub use self::delete_file::DeleteFiles;
+mod trash_files;
+pub use self::trash_files::TrashFiles;
 
 mod rename_file;
 pub use self::rename_file::RenameFile;
@@ -133,7 +133,7 @@ pub fn from_args(command: &str, args: Option<&Vec<String>>) -> Option<Box<dyn Jo
         "cursor_move_page_up" => Some(Box::new(self::CursorMovePageUp::new())),
         "cursor_move_page_down" => Some(Box::new(self::CursorMovePageDown::new())),
         "cut_files" => Some(Box::new(self::CutFiles::new())),
-        "delete_files" => Some(Box::new(self::DeleteFiles::new())),
+        "trash_files" => Some(Box::new(self::TrashFiles::new())),
         "mkdir" => Some(Box::new(self::NewDirectory::new())),
         "new_tab" => Some(Box::new(self::NewTab::new())),
         "open_file" => Some(Box::new(self::OpenFile::new())),
@@ -291,4 +291,3 @@ pub fn split_shell_style(line: &String) -> Vec<&str>
     }
     args
 }
-

--- a/src/joshuto/command/trash_files.rs
+++ b/src/joshuto/command/trash_files.rs
@@ -43,29 +43,19 @@ impl std::fmt::Display for TrashFiles {
 impl JoshutoRunnable for TrashFiles {
     fn execute(&self, context: &mut JoshutoContext)
     {
-        ui::wprint_msg(&context.views.bot_win, "Trash selected files? (Y/n)");
-        ncurses::timeout(-1);
-        ncurses::doupdate();
-
-        let ch: i32 = ncurses::getch();
-        if ch == 'y' as i32 || ch == keymap::ENTER as i32 {
-            if let Some(s) = context.tabs[context.curr_tab_index].curr_list.as_ref() {
-                if let Some(paths) = command::collect_selected_paths(s) {
-                    Self::trash_files(paths);
-                }
+        if let Some(s) = context.tabs[context.curr_tab_index].curr_list.as_ref() {
+            if let Some(paths) = command::collect_selected_paths(s) {
+                Self::trash_files(paths);
             }
-            ui::wprint_msg(&context.views.bot_win, "Trashed files");
-
-            let curr_tab = &mut context.tabs[context.curr_tab_index];
-            curr_tab.reload_contents(&context.config_t.sort_type);
-            curr_tab.refresh(&context.views, &context.config_t,
-                &context.username, &context.hostname);
-        } else {
-            let curr_tab = &context.tabs[context.curr_tab_index];
-            curr_tab.refresh_file_status(&context.views.bot_win);
-            curr_tab.refresh_path_status(&context.views.top_win,
-                    &context.username, &context.hostname);
         }
+
+        ui::wprint_msg(&context.views.bot_win, "Trashed files");
+
+        let curr_tab = &mut context.tabs[context.curr_tab_index];
+        curr_tab.reload_contents(&context.config_t.sort_type);
+        curr_tab.refresh(&context.views, &context.config_t,
+            &context.username, &context.hostname);
+
         ncurses::doupdate();
     }
 }

--- a/src/joshuto/command/trash_files.rs
+++ b/src/joshuto/command/trash_files.rs
@@ -26,6 +26,7 @@ impl TrashFiles {
     pub fn trash_files(paths: Vec<path::PathBuf>)
     {
         let trash_dir = get_trash_dir();
+        fs::create_dir_all(&trash_dir);
         fs_extra::move_items(&paths, trash_dir, &fs_extra::dir::CopyOptions::new());
     }
 }


### PR DESCRIPTION
So let me know if you have any thoughts on this, but this PR basically renames the `delete_files` command to `trash_files` and changes its behavior so it moves the files to the XDG defined trash folder instead of `rm`ing them. I think in the age of the Linux desktop, `rm`ing files is pretty outdated and it's much better to use the trash, at least for most tasks. If you think people would want the `delete_files` command too, then we could add that back in this PR. But either way, I think `trash_files` would be a better default to use in the default config instead of the `delete_files` command.