### PR TITLE
Fix bitwise-and build issues on macOS

### DIFF
--- a/src/util/unix.rs
+++ b/src/util/unix.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 pub fn is_executable(mode: u32) -> bool {
     const LIBC_PERMISSION_VALS: [libc::mode_t; 3] = [libc::S_IXUSR, libc::S_IXGRP, libc::S_IXOTH];
 
-    LIBC_PERMISSION_VALS.iter().any(|val| mode & *val != 0)
+    LIBC_PERMISSION_VALS.iter().any(|val| mode & (*val as u32) != 0)
 }
 
 pub fn stringify_mode(mode: u32) -> String {


### PR DESCRIPTION
I was seeing build errors due to attempting to bitwise-and a u32 and a u16:

```
error[E0308]: mismatched types
 --> src/util/unix.rs:6:50
  |
6 |     LIBC_PERMISSION_VALS.iter().any(|val| mode & *val != 0)
  |                                                  ^^^^ expected `u32`, found `u16`

error[E0277]: no implementation for `u32 & u16`
 --> src/util/unix.rs:6:48
  |
6 |     LIBC_PERMISSION_VALS.iter().any(|val| mode & *val != 0)
  |                                                ^ no implementation for `u32 & u16`
  |
  = help: the trait `std::ops::BitAnd<u16>` is not implemented for `u32`
```

I fixed this by simply up-converting `*val` to a `u32`.

The widening won't have any effect on functionality because we don't care about any of the higher bits.

(probably) Fixes #22 