### PR TITLE
Fix rendering of inner borders.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -253,7 +253,7 @@ dependencies = [
 
 [[package]]
 name = "joshuto"
-version = "0.8.6"
+version = "0.9.0"
 dependencies = [
  "alphanumeric-sort",
  "chrono",
@@ -263,7 +263,7 @@ dependencies = [
  "libc",
  "open",
  "phf",
- "rand 0.8.3",
+ "rand",
  "rustyline",
  "serde",
  "serde_derive",
@@ -374,7 +374,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17367f0cc86f2d25802b2c26ee58a7b23faeccf78a396094c13dced0d0182526"
 dependencies = [
  "phf_shared",
- "rand 0.7.3",
+ "rand",
 ]
 
 [[package]]
@@ -462,22 +462,10 @@ checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
  "getrandom 0.1.16",
  "libc",
- "rand_chacha 0.2.2",
- "rand_core 0.5.1",
- "rand_hc 0.2.0",
+ "rand_chacha",
+ "rand_core",
+ "rand_hc",
  "rand_pcg",
-]
-
-[[package]]
-name = "rand"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
-dependencies = [
- "libc",
- "rand_chacha 0.3.0",
- "rand_core 0.6.2",
- "rand_hc 0.3.0",
 ]
 
 [[package]]
@@ -487,17 +475,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.5.1",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.2",
+ "rand_core",
 ]
 
 [[package]]
@@ -510,30 +488,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_core"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
-dependencies = [
- "getrandom 0.2.2",
-]
-
-[[package]]
 name = "rand_hc"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
- "rand_core 0.5.1",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
-dependencies = [
- "rand_core 0.6.2",
+ "rand_core",
 ]
 
 [[package]]
@@ -542,7 +502,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
 dependencies = [
- "rand_core 0.5.1",
+ "rand_core",
 ]
 
 [[package]]

--- a/src/ui/views/tui_folder_view.rs
+++ b/src/ui/views/tui_folder_view.rs
@@ -1,9 +1,9 @@
 use tui::buffer::Buffer;
 use tui::layout::{Constraint, Direction, Layout, Rect};
 use tui::style::{Color, Style};
+use tui::symbols::line::{HORIZONTAL_DOWN, HORIZONTAL_UP};
 use tui::text::Span;
 use tui::widgets::{Block, Borders, Paragraph, Widget, Wrap};
-use tui::symbols::line::{HORIZONTAL_UP,HORIZONTAL_DOWN};
 
 use crate::context::AppContext;
 use crate::ui::widgets::{TuiDirList, TuiDirListDetailed, TuiFooter, TuiTabBar, TuiTopBar};
@@ -63,9 +63,14 @@ impl<'a> Widget for TuiFolderView<'a> {
             {
                 let top = area.top();
                 let bottom = area.bottom() - 1;
-                let left  = layout_rect[1].left() - 1;
+                let left = layout_rect[1].left() - 1;
                 let right = layout_rect[2].left();
-                let intersections = Intersections { top, bottom, left, right };
+                let intersections = Intersections {
+                    top,
+                    bottom,
+                    left,
+                    right,
+                };
 
                 if parent_list.as_ref().is_some() {
                     intersections.render_left(buf);
@@ -74,7 +79,6 @@ impl<'a> Widget for TuiFolderView<'a> {
                     intersections.render_right(buf);
                 }
             }
-
 
             let block = Block::default().borders(Borders::RIGHT);
             let inner1 = block.inner(layout_rect[0]);
@@ -180,7 +184,6 @@ impl<'a> Widget for TuiFolderView<'a> {
     }
 }
 
-
 struct Intersections {
     top: u16,
     bottom: u16,
@@ -189,13 +192,12 @@ struct Intersections {
 }
 
 impl Intersections {
-    fn render_left(&self,buf: &mut Buffer) {
-        buf.get_mut(self.left, self.top)
-            .set_symbol(HORIZONTAL_DOWN);
+    fn render_left(&self, buf: &mut Buffer) {
+        buf.get_mut(self.left, self.top).set_symbol(HORIZONTAL_DOWN);
         buf.get_mut(self.left, self.bottom)
             .set_symbol(HORIZONTAL_UP);
     }
-    fn render_right(&self,buf: &mut Buffer) {
+    fn render_right(&self, buf: &mut Buffer) {
         buf.get_mut(self.right, self.top)
             .set_symbol(HORIZONTAL_DOWN);
         buf.get_mut(self.right, self.bottom)

--- a/src/ui/views/tui_folder_view.rs
+++ b/src/ui/views/tui_folder_view.rs
@@ -3,6 +3,7 @@ use tui::layout::{Constraint, Direction, Layout, Rect};
 use tui::style::{Color, Style};
 use tui::text::Span;
 use tui::widgets::{Block, Borders, Paragraph, Widget, Wrap};
+use tui::symbols::line::{HORIZONTAL_UP,HORIZONTAL_DOWN};
 
 use crate::context::AppContext;
 use crate::ui::widgets::{TuiDirList, TuiDirListDetailed, TuiFooter, TuiTabBar, TuiTopBar};
@@ -48,6 +49,7 @@ impl<'a> Widget for TuiFolderView<'a> {
                 height: area.height - 2,
                 ..area
             };
+
             let block = Block::default().borders(Borders::ALL);
             let inner = block.inner(area);
             block.render(area, buf);
@@ -56,6 +58,23 @@ impl<'a> Widget for TuiFolderView<'a> {
                 .direction(Direction::Horizontal)
                 .constraints(constraints.as_ref())
                 .split(inner);
+
+            // Render inner borders properly.
+            {
+                let top = area.top();
+                let bottom = area.bottom() - 1;
+                let left  = layout_rect[1].left() - 1;
+                let right = layout_rect[2].left();
+                let intersections = Intersections { top, bottom, left, right };
+
+                if parent_list.as_ref().is_some() {
+                    intersections.render_left(buf);
+                }
+                if child_list.as_ref().is_some() {
+                    intersections.render_right(buf);
+                }
+            }
+
 
             let block = Block::default().borders(Borders::RIGHT);
             let inner1 = block.inner(layout_rect[0]);
@@ -158,5 +177,28 @@ impl<'a> Widget for TuiFolderView<'a> {
             )
             .render(rect, buf);
         }
+    }
+}
+
+
+struct Intersections {
+    top: u16,
+    bottom: u16,
+    left: u16,
+    right: u16,
+}
+
+impl Intersections {
+    fn render_left(&self,buf: &mut Buffer) {
+        buf.get_mut(self.left, self.top)
+            .set_symbol(HORIZONTAL_DOWN);
+        buf.get_mut(self.left, self.bottom)
+            .set_symbol(HORIZONTAL_UP);
+    }
+    fn render_right(&self,buf: &mut Buffer) {
+        buf.get_mut(self.right, self.top)
+            .set_symbol(HORIZONTAL_DOWN);
+        buf.get_mut(self.right, self.bottom)
+            .set_symbol(HORIZONTAL_UP);
     }
 }


### PR DESCRIPTION
This makes the rendering of  borders of tui_folder_view more consistent with that of ranger or lf.

![fixed_borders](https://user-images.githubusercontent.com/75972193/118051504-d166d180-b389-11eb-85a8-cacd42033052.png)
