### PR TITLE
Sorting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,0 @@
-/target
-/test
-*.log
-*.tmp
-*~
-**/*.rs.bk

--- a/config/keymap.toml
+++ b/config/keymap.toml
@@ -170,9 +170,6 @@ keys = [ "s", "n" ]
 [[mapcommand]]
 command = "sort reverse"
 keys = [ "s", "r" ]
-[[mapcommand]]
-command = "sort ext"
-keys = [ "s", "e" ]
 
 [[mapcommand]]
 command = "cd /"

--- a/config/keymap.toml
+++ b/config/keymap.toml
@@ -170,6 +170,9 @@ keys = [ "s", "n" ]
 [[mapcommand]]
 command = "sort reverse"
 keys = [ "s", "r" ]
+[[mapcommand]]
+command = "sort ext"
+keys = [ "s", "e" ]
 
 [[mapcommand]]
 command = "cd /"

--- a/src/commands/sort.rs
+++ b/src/commands/sort.rs
@@ -8,8 +8,10 @@ use crate::util::sort::SortType;
 use super::reload;
 
 pub fn set_sort(context: &mut AppContext, method: SortType) -> JoshutoResult<()> {
-    context.config_mut().sort_options_mut().sort_method = method;
-
+    context
+        .config_mut()
+        .sort_options_mut()
+        .set_sort_method(method);
     for tab in context.tab_context_mut().iter_mut() {
         tab.history_mut().depreciate_all_entries();
     }

--- a/src/config/default/sort.rs
+++ b/src/config/default/sort.rs
@@ -1,6 +1,7 @@
 use serde_derive::Deserialize;
 
 use crate::util::sort;
+use crate::util::sort::SortType;
 
 const fn default_true() -> bool {
     true
@@ -24,11 +25,21 @@ impl SortRawOption {
             Some(s) => sort::SortType::parse(s).unwrap_or(sort::SortType::Natural),
             None => sort::SortType::Natural,
         };
+
+        let mut sort_methods = std::collections::LinkedList::new();
+        sort_methods.push_back(SortType::Ext);
+        sort_methods.push_back(SortType::Size);
+        sort_methods.push_back(SortType::Mtime);
+        sort_methods.push_back(SortType::Lexical);
+        sort_methods.push_back(SortType::Natural);
+
+        let sort_methods = sort::SortTypes { list: sort_methods };
         sort::SortOption {
             directories_first: self.directories_first,
             case_sensitive: self.case_sensitive,
             reverse: self.reverse,
             sort_method,
+            sort_methods,
         }
     }
 }

--- a/src/fs/entry.rs
+++ b/src/fs/entry.rs
@@ -86,6 +86,15 @@ impl JoshutoDirEntry {
     pub fn set_selected(&mut self, selected: bool) {
         self.selected = selected;
     }
+
+    pub fn get_ext(&self) -> &str {
+        let fname = self.file_name();
+        let ext = match fname.rfind('.') {
+            Some(pos) => &fname[pos..],
+            None => &fname[0..0],
+        };
+        ext
+    }
 }
 
 impl std::fmt::Display for JoshutoDirEntry {

--- a/src/util/sort.rs
+++ b/src/util/sort.rs
@@ -6,12 +6,40 @@ use serde_derive::Deserialize;
 
 use crate::fs::JoshutoDirEntry;
 
-#[derive(Clone, Copy, Debug, Deserialize)]
+#[derive(Clone, Debug)]
+pub struct SortTypes {
+    pub list: std::collections::LinkedList<SortType>,
+}
+
+impl SortTypes {
+    pub fn reorganize(&mut self, st: SortType) {
+        self.list.push_front(st);
+        self.list.pop_back();
+    }
+
+    pub fn cmp(
+        &self,
+        f1: &JoshutoDirEntry,
+        f2: &JoshutoDirEntry,
+        sort_option: &SortOption,
+    ) -> cmp::Ordering {
+        for st in &self.list {
+            let res = st.cmp(f1, f2, sort_option);
+            if res != cmp::Ordering::Equal {
+                return res;
+            }
+        }
+        cmp::Ordering::Equal
+    }
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq)]
 pub enum SortType {
     Lexical,
     Mtime,
     Natural,
     Size,
+    Ext,
 }
 
 impl SortType {
@@ -21,6 +49,7 @@ impl SortType {
             "mtime" => Some(SortType::Mtime),
             "natural" => Some(SortType::Natural),
             "size" => Some(SortType::Size),
+            "ext" => Some(SortType::Ext),
             _ => None,
         }
     }
@@ -30,7 +59,23 @@ impl SortType {
             SortType::Mtime => "mtime",
             SortType::Natural => "natural",
             SortType::Size => "size",
+            SortType::Ext => "ext",
         }
+    }
+    pub fn cmp(
+        &self,
+        f1: &JoshutoDirEntry,
+        f2: &JoshutoDirEntry,
+        sort_option: &SortOption,
+    ) -> cmp::Ordering {
+        let res = match &self {
+            SortType::Natural => natural_sort(f1, f2, sort_option),
+            SortType::Lexical => lexical_sort(f1, f2, sort_option),
+            SortType::Size => size_sort(f1, f2),
+            SortType::Mtime => mtime_sort(f1, f2),
+            SortType::Ext => ext_sort(f1, f2),
+        };
+        return res;
     }
 }
 
@@ -46,9 +91,14 @@ pub struct SortOption {
     pub case_sensitive: bool,
     pub reverse: bool,
     pub sort_method: SortType,
+    pub sort_methods: SortTypes,
 }
 
 impl SortOption {
+    pub fn set_sort_method(&mut self, method: SortType) {
+        self.sort_methods.reorganize(method);
+    }
+
     pub fn compare(&self, f1: &JoshutoDirEntry, f2: &JoshutoDirEntry) -> cmp::Ordering {
         if self.directories_first {
             let f1_isdir = f1.file_path().is_dir();
@@ -61,51 +111,33 @@ impl SortOption {
             }
         }
 
-        let mut res = match self.sort_method {
-            SortType::Lexical => {
-                let f1_name = f1.file_name();
-                let f2_name = f2.file_name();
-                if self.case_sensitive {
-                    f1_name.cmp(&f2_name)
-                } else {
-                    let f1_name = f1_name.to_lowercase();
-                    let f2_name = f2_name.to_lowercase();
-                    f1_name.cmp(&f2_name)
-                }
-            }
-            SortType::Natural => {
-                let f1_name = f1.file_name();
-                let f2_name = f2.file_name();
-                if self.case_sensitive {
-                    alphanumeric_sort::compare_str(&f1_name, &f2_name)
-                } else {
-                    let f1_name = f1_name.to_lowercase();
-                    let f2_name = f2_name.to_lowercase();
-                    alphanumeric_sort::compare_str(&f1_name, &f2_name)
-                }
-            }
-            SortType::Mtime => mtime_sort(f1, f2),
-            SortType::Size => size_sort(f1, f2),
-        };
-
+        // let mut res = self.sort_method.cmp(f1, f2, &self);
+        let mut res = self.sort_methods.cmp(f1, f2, &self);
         if self.reverse {
             res = match res {
                 cmp::Ordering::Less => cmp::Ordering::Greater,
                 cmp::Ordering::Greater => cmp::Ordering::Less,
                 s => s,
             };
-        }
+        };
         res
     }
 }
 
 impl std::default::Default for SortOption {
     fn default() -> Self {
+        let mut sort_methods = std::collections::LinkedList::new();
+        sort_methods.push_back(SortType::Ext);
+        sort_methods.push_back(SortType::Size);
+        sort_methods.push_back(SortType::Mtime);
+        sort_methods.push_back(SortType::Lexical);
+        sort_methods.push_back(SortType::Natural);
         SortOption {
             directories_first: true,
             case_sensitive: false,
             reverse: false,
             sort_method: SortType::Natural,
+            sort_methods: SortTypes { list: sort_methods },
         }
     }
 }
@@ -132,4 +164,42 @@ fn mtime_sort(file1: &JoshutoDirEntry, file2: &JoshutoDirEntry) -> cmp::Ordering
 
 fn size_sort(file1: &JoshutoDirEntry, file2: &JoshutoDirEntry) -> cmp::Ordering {
     file1.metadata.len().cmp(&file2.metadata.len())
+}
+
+fn ext_sort(file1: &JoshutoDirEntry, file2: &JoshutoDirEntry) -> cmp::Ordering {
+    let f1_ext = file1.get_ext();
+    let f2_ext = file2.get_ext();
+    alphanumeric_sort::compare_str(&f1_ext, &f2_ext)
+}
+
+fn lexical_sort(
+    f1: &JoshutoDirEntry,
+    f2: &JoshutoDirEntry,
+    sort_option: &SortOption,
+) -> cmp::Ordering {
+    let f1_name = f1.file_name();
+    let f2_name = f2.file_name();
+    if sort_option.case_sensitive {
+        f1_name.cmp(&f2_name)
+    } else {
+        let f1_name = f1_name.to_lowercase();
+        let f2_name = f2_name.to_lowercase();
+        f1_name.cmp(&f2_name)
+    }
+}
+
+fn natural_sort(
+    f1: &JoshutoDirEntry,
+    f2: &JoshutoDirEntry,
+    sort_option: &SortOption,
+) -> cmp::Ordering {
+    let f1_name = f1.file_name();
+    let f2_name = f2.file_name();
+    if sort_option.case_sensitive {
+        alphanumeric_sort::compare_str(&f1_name, &f2_name)
+    } else {
+        let f1_name = f1_name.to_lowercase();
+        let f2_name = f2_name.to_lowercase();
+        alphanumeric_sort::compare_str(&f1_name, &f2_name)
+    }
 }

--- a/src/util/sort.rs
+++ b/src/util/sort.rs
@@ -6,40 +6,12 @@ use serde_derive::Deserialize;
 
 use crate::fs::JoshutoDirEntry;
 
-#[derive(Clone, Debug)]
-pub struct SortTypes {
-    pub list: std::collections::LinkedList<SortType>,
-}
-
-impl SortTypes {
-    pub fn reorganize(&mut self, st: SortType) {
-        self.list.push_front(st);
-        self.list.pop_back();
-    }
-
-    pub fn cmp(
-        &self,
-        f1: &JoshutoDirEntry,
-        f2: &JoshutoDirEntry,
-        sort_option: &SortOption,
-    ) -> cmp::Ordering {
-        for st in &self.list {
-            let res = st.cmp(f1, f2, sort_option);
-            if res != cmp::Ordering::Equal {
-                return res;
-            }
-        }
-        cmp::Ordering::Equal
-    }
-}
-
-#[derive(Clone, Copy, Debug, Deserialize, PartialEq)]
+#[derive(Clone, Copy, Debug, Deserialize)]
 pub enum SortType {
     Lexical,
     Mtime,
     Natural,
     Size,
-    Ext,
 }
 
 impl SortType {
@@ -49,7 +21,6 @@ impl SortType {
             "mtime" => Some(SortType::Mtime),
             "natural" => Some(SortType::Natural),
             "size" => Some(SortType::Size),
-            "ext" => Some(SortType::Ext),
             _ => None,
         }
     }
@@ -59,23 +30,7 @@ impl SortType {
             SortType::Mtime => "mtime",
             SortType::Natural => "natural",
             SortType::Size => "size",
-            SortType::Ext => "ext",
         }
-    }
-    pub fn cmp(
-        &self,
-        f1: &JoshutoDirEntry,
-        f2: &JoshutoDirEntry,
-        sort_option: &SortOption,
-    ) -> cmp::Ordering {
-        let res = match &self {
-            SortType::Natural => natural_sort(f1, f2, sort_option),
-            SortType::Lexical => lexical_sort(f1, f2, sort_option),
-            SortType::Size => size_sort(f1, f2),
-            SortType::Mtime => mtime_sort(f1, f2),
-            SortType::Ext => ext_sort(f1, f2),
-        };
-        return res;
     }
 }
 
@@ -91,14 +46,9 @@ pub struct SortOption {
     pub case_sensitive: bool,
     pub reverse: bool,
     pub sort_method: SortType,
-    pub sort_methods: SortTypes,
 }
 
 impl SortOption {
-    pub fn set_sort_method(&mut self, method: SortType) {
-        self.sort_methods.reorganize(method);
-    }
-
     pub fn compare(&self, f1: &JoshutoDirEntry, f2: &JoshutoDirEntry) -> cmp::Ordering {
         if self.directories_first {
             let f1_isdir = f1.file_path().is_dir();
@@ -111,33 +61,51 @@ impl SortOption {
             }
         }
 
-        // let mut res = self.sort_method.cmp(f1, f2, &self);
-        let mut res = self.sort_methods.cmp(f1, f2, &self);
+        let mut res = match self.sort_method {
+            SortType::Lexical => {
+                let f1_name = f1.file_name();
+                let f2_name = f2.file_name();
+                if self.case_sensitive {
+                    f1_name.cmp(&f2_name)
+                } else {
+                    let f1_name = f1_name.to_lowercase();
+                    let f2_name = f2_name.to_lowercase();
+                    f1_name.cmp(&f2_name)
+                }
+            }
+            SortType::Natural => {
+                let f1_name = f1.file_name();
+                let f2_name = f2.file_name();
+                if self.case_sensitive {
+                    alphanumeric_sort::compare_str(&f1_name, &f2_name)
+                } else {
+                    let f1_name = f1_name.to_lowercase();
+                    let f2_name = f2_name.to_lowercase();
+                    alphanumeric_sort::compare_str(&f1_name, &f2_name)
+                }
+            }
+            SortType::Mtime => mtime_sort(f1, f2),
+            SortType::Size => size_sort(f1, f2),
+        };
+
         if self.reverse {
             res = match res {
                 cmp::Ordering::Less => cmp::Ordering::Greater,
                 cmp::Ordering::Greater => cmp::Ordering::Less,
                 s => s,
             };
-        };
+        }
         res
     }
 }
 
 impl std::default::Default for SortOption {
     fn default() -> Self {
-        let mut sort_methods = std::collections::LinkedList::new();
-        sort_methods.push_back(SortType::Ext);
-        sort_methods.push_back(SortType::Size);
-        sort_methods.push_back(SortType::Mtime);
-        sort_methods.push_back(SortType::Lexical);
-        sort_methods.push_back(SortType::Natural);
         SortOption {
             directories_first: true,
             case_sensitive: false,
             reverse: false,
             sort_method: SortType::Natural,
-            sort_methods: SortTypes { list: sort_methods },
         }
     }
 }
@@ -152,54 +120,16 @@ fn mtime_sort(file1: &JoshutoDirEntry, file2: &JoshutoDirEntry) -> cmp::Ordering
 
         let f1_mtime: time::SystemTime = f1_meta.modified()?;
         let f2_mtime: time::SystemTime = f2_meta.modified()?;
-
-        Ok(if f1_mtime >= f2_mtime {
-            cmp::Ordering::Less
-        } else {
-            cmp::Ordering::Greater
-        })
+        Ok(f1_mtime.cmp(&f2_mtime))
+        // Ok(if f1_mtime >= f2_mtime {
+        //     cmp::Ordering::Less
+        // } else {
+        //     cmp::Ordering::Greater
+        // })
     }
-    compare(&file1, &file2).unwrap_or(cmp::Ordering::Less)
+    compare(&file1, &file2).unwrap_or(cmp::Ordering::Equal)
 }
 
 fn size_sort(file1: &JoshutoDirEntry, file2: &JoshutoDirEntry) -> cmp::Ordering {
     file1.metadata.len().cmp(&file2.metadata.len())
-}
-
-fn ext_sort(file1: &JoshutoDirEntry, file2: &JoshutoDirEntry) -> cmp::Ordering {
-    let f1_ext = file1.get_ext();
-    let f2_ext = file2.get_ext();
-    alphanumeric_sort::compare_str(&f1_ext, &f2_ext)
-}
-
-fn lexical_sort(
-    f1: &JoshutoDirEntry,
-    f2: &JoshutoDirEntry,
-    sort_option: &SortOption,
-) -> cmp::Ordering {
-    let f1_name = f1.file_name();
-    let f2_name = f2.file_name();
-    if sort_option.case_sensitive {
-        f1_name.cmp(&f2_name)
-    } else {
-        let f1_name = f1_name.to_lowercase();
-        let f2_name = f2_name.to_lowercase();
-        f1_name.cmp(&f2_name)
-    }
-}
-
-fn natural_sort(
-    f1: &JoshutoDirEntry,
-    f2: &JoshutoDirEntry,
-    sort_option: &SortOption,
-) -> cmp::Ordering {
-    let f1_name = f1.file_name();
-    let f2_name = f2.file_name();
-    if sort_option.case_sensitive {
-        alphanumeric_sort::compare_str(&f1_name, &f2_name)
-    } else {
-        let f1_name = f1_name.to_lowercase();
-        let f2_name = f2_name.to_lowercase();
-        alphanumeric_sort::compare_str(&f1_name, &f2_name)
-    }
 }

--- a/src/util/sort.rs
+++ b/src/util/sort.rs
@@ -6,12 +6,40 @@ use serde_derive::Deserialize;
 
 use crate::fs::JoshutoDirEntry;
 
-#[derive(Clone, Copy, Debug, Deserialize)]
+#[derive(Clone, Debug)]
+pub struct SortTypes {
+    pub list: std::collections::LinkedList<SortType>,
+}
+
+impl SortTypes {
+    pub fn reorganize(&mut self, st: SortType) {
+        self.list.push_front(st);
+        self.list.pop_back();
+    }
+
+    pub fn cmp(
+        &self,
+        f1: &JoshutoDirEntry,
+        f2: &JoshutoDirEntry,
+        sort_option: &SortOption,
+    ) -> cmp::Ordering {
+        for st in &self.list {
+            let res = st.cmp(f1, f2, sort_option);
+            if res != cmp::Ordering::Equal {
+                return res;
+            }
+        }
+        cmp::Ordering::Equal
+    }
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq)]
 pub enum SortType {
     Lexical,
     Mtime,
     Natural,
     Size,
+    Ext,
 }
 
 impl SortType {
@@ -21,6 +49,7 @@ impl SortType {
             "mtime" => Some(SortType::Mtime),
             "natural" => Some(SortType::Natural),
             "size" => Some(SortType::Size),
+            "ext" => Some(SortType::Ext),
             _ => None,
         }
     }
@@ -30,7 +59,23 @@ impl SortType {
             SortType::Mtime => "mtime",
             SortType::Natural => "natural",
             SortType::Size => "size",
+            SortType::Ext => "ext",
         }
+    }
+    pub fn cmp(
+        &self,
+        f1: &JoshutoDirEntry,
+        f2: &JoshutoDirEntry,
+        sort_option: &SortOption,
+    ) -> cmp::Ordering {
+        let res = match &self {
+            SortType::Natural => natural_sort(f1, f2, sort_option),
+            SortType::Lexical => lexical_sort(f1, f2, sort_option),
+            SortType::Size => size_sort(f1, f2),
+            SortType::Mtime => mtime_sort(f1, f2),
+            SortType::Ext => ext_sort(f1, f2),
+        };
+        return res;
     }
 }
 
@@ -46,9 +91,14 @@ pub struct SortOption {
     pub case_sensitive: bool,
     pub reverse: bool,
     pub sort_method: SortType,
+    pub sort_methods: SortTypes,
 }
 
 impl SortOption {
+    pub fn set_sort_method(&mut self, method: SortType) {
+        self.sort_methods.reorganize(method);
+    }
+
     pub fn compare(&self, f1: &JoshutoDirEntry, f2: &JoshutoDirEntry) -> cmp::Ordering {
         if self.directories_first {
             let f1_isdir = f1.file_path().is_dir();
@@ -61,51 +111,33 @@ impl SortOption {
             }
         }
 
-        let mut res = match self.sort_method {
-            SortType::Lexical => {
-                let f1_name = f1.file_name();
-                let f2_name = f2.file_name();
-                if self.case_sensitive {
-                    f1_name.cmp(&f2_name)
-                } else {
-                    let f1_name = f1_name.to_lowercase();
-                    let f2_name = f2_name.to_lowercase();
-                    f1_name.cmp(&f2_name)
-                }
-            }
-            SortType::Natural => {
-                let f1_name = f1.file_name();
-                let f2_name = f2.file_name();
-                if self.case_sensitive {
-                    alphanumeric_sort::compare_str(&f1_name, &f2_name)
-                } else {
-                    let f1_name = f1_name.to_lowercase();
-                    let f2_name = f2_name.to_lowercase();
-                    alphanumeric_sort::compare_str(&f1_name, &f2_name)
-                }
-            }
-            SortType::Mtime => mtime_sort(f1, f2),
-            SortType::Size => size_sort(f1, f2),
-        };
-
+        // let mut res = self.sort_method.cmp(f1, f2, &self);
+        let mut res = self.sort_methods.cmp(f1, f2, &self);
         if self.reverse {
             res = match res {
                 cmp::Ordering::Less => cmp::Ordering::Greater,
                 cmp::Ordering::Greater => cmp::Ordering::Less,
                 s => s,
             };
-        }
+        };
         res
     }
 }
 
 impl std::default::Default for SortOption {
     fn default() -> Self {
+        let mut sort_methods = std::collections::LinkedList::new();
+        sort_methods.push_back(SortType::Ext);
+        sort_methods.push_back(SortType::Size);
+        sort_methods.push_back(SortType::Mtime);
+        sort_methods.push_back(SortType::Lexical);
+        sort_methods.push_back(SortType::Natural);
         SortOption {
             directories_first: true,
             case_sensitive: false,
             reverse: false,
             sort_method: SortType::Natural,
+            sort_methods: SortTypes { list: sort_methods },
         }
     }
 }
@@ -121,6 +153,7 @@ fn mtime_sort(file1: &JoshutoDirEntry, file2: &JoshutoDirEntry) -> cmp::Ordering
         let f1_mtime: time::SystemTime = f1_meta.modified()?;
         let f2_mtime: time::SystemTime = f2_meta.modified()?;
         Ok(f1_mtime.cmp(&f2_mtime))
+
         // Ok(if f1_mtime >= f2_mtime {
         //     cmp::Ordering::Less
         // } else {
@@ -132,4 +165,42 @@ fn mtime_sort(file1: &JoshutoDirEntry, file2: &JoshutoDirEntry) -> cmp::Ordering
 
 fn size_sort(file1: &JoshutoDirEntry, file2: &JoshutoDirEntry) -> cmp::Ordering {
     file1.metadata.len().cmp(&file2.metadata.len())
+}
+
+fn ext_sort(file1: &JoshutoDirEntry, file2: &JoshutoDirEntry) -> cmp::Ordering {
+    let f1_ext = file1.get_ext();
+    let f2_ext = file2.get_ext();
+    alphanumeric_sort::compare_str(&f1_ext, &f2_ext)
+}
+
+fn lexical_sort(
+    f1: &JoshutoDirEntry,
+    f2: &JoshutoDirEntry,
+    sort_option: &SortOption,
+) -> cmp::Ordering {
+    let f1_name = f1.file_name();
+    let f2_name = f2.file_name();
+    if sort_option.case_sensitive {
+        f1_name.cmp(&f2_name)
+    } else {
+        let f1_name = f1_name.to_lowercase();
+        let f2_name = f2_name.to_lowercase();
+        f1_name.cmp(&f2_name)
+    }
+}
+
+fn natural_sort(
+    f1: &JoshutoDirEntry,
+    f2: &JoshutoDirEntry,
+    sort_option: &SortOption,
+) -> cmp::Ordering {
+    let f1_name = f1.file_name();
+    let f2_name = f2.file_name();
+    if sort_option.case_sensitive {
+        alphanumeric_sort::compare_str(&f1_name, &f2_name)
+    } else {
+        let f1_name = f1_name.to_lowercase();
+        let f2_name = f2_name.to_lowercase();
+        alphanumeric_sort::compare_str(&f1_name, &f2_name)
+    }
 }


### PR DESCRIPTION
- `utils/sort.rs` refactored;
- sorting by file extension added;
- sort by extension key binding added;
- if you sort by extension, files with same extensions are sorted by previously enabled sorting method:

for example, if you consequently call
`sort lexical`
`sort ext`
you will get something like:

![snse](https://user-images.githubusercontent.com/47630715/118496394-9d860600-b713-11eb-94d9-e63a29967423.png)

or if you consequently call
`sort size`
`sort ext`
you will get something like:
![ssse](https://user-images.githubusercontent.com/47630715/118496326-8cd59000-b713-11eb-827f-eb14b9a8bbdc.png)


