### PR TITLE
Clear the Screen Before Bulk Renaming

### DIFF
--- a/src/commands/bulk_rename.rs
+++ b/src/commands/bulk_rename.rs
@@ -81,6 +81,9 @@ pub fn _bulk_rename(context: &mut AppContext) -> JoshutoResult<()> {
         ));
     }
 
+    println!("{}", termion::clear::All);
+    termion::cursor::Goto(0,0);
+
     for (p, q) in paths.iter().zip(paths_renamed.iter()) {
         println!("{:?} -> {:?}", p, q);
     }

--- a/src/commands/bulk_rename.rs
+++ b/src/commands/bulk_rename.rs
@@ -82,7 +82,7 @@ pub fn _bulk_rename(context: &mut AppContext) -> JoshutoResult<()> {
     }
 
     println!("{}", termion::clear::All);
-    termion::cursor::Goto(0,0);
+    termion::cursor::Goto(0, 0);
 
     for (p, q) in paths.iter().zip(paths_renamed.iter()) {
         println!("{:?} -> {:?}", p, q);


### PR DESCRIPTION
A while after I do multiple bulk renames the screen becomes really messy containing files from previous bulk renames. This is a very simple fix. Maybe this could be improved a bit.