### PR TITLE
Add spawn command

### DIFF
--- a/src/commands/key_command.rs
+++ b/src/commands/key_command.rs
@@ -417,8 +417,10 @@ impl AppExecute for KeyCommand {
                 selection::select_files(context, pattern.as_str(), &options)
             }
             Self::SetMode => set_mode::set_mode(context, backend),
-            Self::ShellCommand(v) => shell::shell(context, backend, v.as_slice(), false),
-            Self::SpawnCommand(v) => shell::shell(context, backend, v.as_slice(), true),
+            Self::ShellCommand(v) => {
+                sub_process::sub_process(context, backend, v.as_slice(), false)
+            }
+            Self::SpawnCommand(v) => sub_process::sub_process(context, backend, v.as_slice(), true),
             Self::ShowWorkers => show_workers::show_workers(context, backend),
 
             Self::ToggleHiddenFiles => show_hidden::toggle_hidden(context),

--- a/src/commands/key_command.rs
+++ b/src/commands/key_command.rs
@@ -61,8 +61,7 @@ pub enum KeyCommand {
 
     SelectFiles(String, SelectOption),
     SetMode,
-    ShellCommand(Vec<String>),
-    SpawnCommand(Vec<String>),
+    SubProcess(Vec<String>, bool),
     ShowWorkers,
 
     ToggleHiddenFiles,
@@ -123,8 +122,8 @@ impl KeyCommand {
 
             Self::SelectFiles(_, _) => "select",
             Self::SetMode => "set_mode",
-            Self::ShellCommand(_) => "shell",
-            Self::SpawnCommand(_) => "spawn",
+            Self::SubProcess(_, false) => "shell",
+            Self::SubProcess(_, true) => "spawn",
             Self::ShowWorkers => "show_workers",
 
             Self::ToggleHiddenFiles => "toggle_hidden",
@@ -316,13 +315,7 @@ impl std::str::FromStr for KeyCommand {
             }
             "set_mode" => Ok(Self::SetMode),
             "shell" | "spawn" => match shell_words::split(arg) {
-                Ok(s) if !s.is_empty() => {
-                    if command == "shell" {
-                        Ok(Self::ShellCommand(s))
-                    } else {
-                        Ok(Self::SpawnCommand(s))
-                    }
-                }
+                Ok(s) if !s.is_empty() => Ok(Self::SubProcess(s, command == "spawn")),
                 Ok(_) => Err(JoshutoError::new(
                     JoshutoErrorKind::InvalidParameters,
                     format!("{}: No commands given", command),
@@ -417,10 +410,9 @@ impl AppExecute for KeyCommand {
                 selection::select_files(context, pattern.as_str(), &options)
             }
             Self::SetMode => set_mode::set_mode(context, backend),
-            Self::ShellCommand(v) => {
-                sub_process::sub_process(context, backend, v.as_slice(), false)
+            Self::SubProcess(v, spawn) => {
+                sub_process::sub_process(context, backend, v.as_slice(), *spawn)
             }
-            Self::SpawnCommand(v) => sub_process::sub_process(context, backend, v.as_slice(), true),
             Self::ShowWorkers => show_workers::show_workers(context, backend),
 
             Self::ToggleHiddenFiles => show_hidden::toggle_hidden(context),
@@ -455,9 +447,7 @@ impl std::fmt::Display for KeyCommand {
             Self::SelectFiles(pattern, options) => {
                 write!(f, "{} {} {}", self.command(), pattern, options)
             }
-            Self::ShellCommand(c) | Self::SpawnCommand(c) => {
-                write!(f, "{} {:?}", self.command(), c)
-            }
+            Self::SubProcess(c, _) => write!(f, "{} {:?}", self.command(), c),
             Self::Sort(t) => write!(f, "{} {}", self.command(), t),
             Self::TabSwitch(i) => write!(f, "{} {}", self.command(), i),
             _ => write!(f, "{}", self.command()),

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -17,10 +17,10 @@ pub mod search_skim;
 pub mod search_string;
 pub mod selection;
 pub mod set_mode;
-pub mod shell;
 pub mod show_hidden;
 pub mod show_workers;
 pub mod sort;
+pub mod sub_process;
 pub mod tab_ops;
 pub mod touch_file;
 

--- a/src/commands/shell.rs
+++ b/src/commands/shell.rs
@@ -48,7 +48,11 @@ pub fn shell(
     backend.terminal_drop();
     let res = shell_command(context, words, spawn);
     reload::soft_reload(context.tab_context_ref().index, context)?;
-    context.push_msg(format!("Finished: {}", words.join(" ")));
+    context.push_msg(format!(
+        "{}: {}",
+        if spawn { "Spawned" } else { "Finished" },
+        words.join(" ")
+    ));
     backend.terminal_restore()?;
     res?;
     Ok(())

--- a/src/commands/shell.rs
+++ b/src/commands/shell.rs
@@ -1,13 +1,12 @@
-use std::process;
-
 use crate::context::AppContext;
 use crate::error::JoshutoResult;
 use crate::ui::TuiBackend;
+use std::process::{Command, Stdio};
 
 use super::reload;
 
 fn shell_command(context: &mut AppContext, words: &[String], spawn: bool) -> std::io::Result<()> {
-    let mut command = process::Command::new(words[0].clone());
+    let mut command = Command::new(words[0].clone());
     for word in words.iter().skip(1) {
         match (*word).as_str() {
             "%s" => {
@@ -30,7 +29,10 @@ fn shell_command(context: &mut AppContext, words: &[String], spawn: bool) -> std
         };
     }
     if spawn {
-        command.spawn()?;
+        command
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()?;
     } else {
         command.status()?;
     }

--- a/src/commands/shell.rs
+++ b/src/commands/shell.rs
@@ -6,7 +6,7 @@ use crate::ui::TuiBackend;
 
 use super::reload;
 
-pub fn shell_command(context: &mut AppContext, words: &[String]) -> std::io::Result<()> {
+fn shell_command(context: &mut AppContext, words: &[String], spawn: bool) -> std::io::Result<()> {
     let mut command = process::Command::new(words[0].clone());
     for word in words.iter().skip(1) {
         match (*word).as_str() {
@@ -29,7 +29,11 @@ pub fn shell_command(context: &mut AppContext, words: &[String]) -> std::io::Res
             }
         };
     }
-    command.status()?;
+    if spawn {
+        command.spawn()?;
+    } else {
+        command.status()?;
+    }
     Ok(())
 }
 
@@ -37,9 +41,10 @@ pub fn shell(
     context: &mut AppContext,
     backend: &mut TuiBackend,
     words: &[String],
+    spawn: bool,
 ) -> JoshutoResult<()> {
     backend.terminal_drop();
-    let res = shell_command(context, words);
+    let res = shell_command(context, words, spawn);
     reload::soft_reload(context.tab_context_ref().index, context)?;
     context.push_msg(format!("Finished: {}", words.join(" ")));
     backend.terminal_restore()?;

--- a/src/commands/sub_process.rs
+++ b/src/commands/sub_process.rs
@@ -5,7 +5,11 @@ use std::process::{Command, Stdio};
 
 use super::reload;
 
-fn shell_command(context: &mut AppContext, words: &[String], spawn: bool) -> std::io::Result<()> {
+fn execute_sub_process(
+    context: &mut AppContext,
+    words: &[String],
+    spawn: bool,
+) -> std::io::Result<()> {
     let mut command = Command::new(words[0].clone());
     for word in words.iter().skip(1) {
         match (*word).as_str() {
@@ -39,14 +43,15 @@ fn shell_command(context: &mut AppContext, words: &[String], spawn: bool) -> std
     Ok(())
 }
 
-pub fn shell(
+/// Handler for Joshuto's `shell` and `spawn` commands.
+pub fn sub_process(
     context: &mut AppContext,
     backend: &mut TuiBackend,
     words: &[String],
     spawn: bool,
 ) -> JoshutoResult<()> {
     backend.terminal_drop();
-    let res = shell_command(context, words, spawn);
+    let res = execute_sub_process(context, words, spawn);
     reload::soft_reload(context.tab_context_ref().index, context)?;
     context.push_msg(format!(
         "{}: {}",


### PR DESCRIPTION
As discussed in  #69, this PR adds a `spawn` command.

When executing a command with spawn, stdout and stderr of the executed sub-process are swallowed, so they don't mess up Joshuto's UI.