### PR TITLE
Show symlinked files and dirs correctly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -536,6 +536,7 @@ dependencies = [
  "toml",
  "trash",
  "tui",
+ "unicode-segmentation",
  "unicode-width",
  "users",
  "whoami",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ whoami = "^0"
 xdg = "^2"
 phf = { version = "^0", features = ["macros"], optional = true }
 trash = { version = "^1", optional = true }
-
+unicode-segmentation = "^1"
 [features]
 devicons = [ "phf" ]
 file_mimetype = []

--- a/src/fs/metadata.rs
+++ b/src/fs/metadata.rs
@@ -38,9 +38,10 @@ impl JoshutoMetadata {
         let _len = metadata.len();
         let _modified = metadata.modified()?;
         let _permissions = metadata.permissions();
-        let _file_type = match metadata.file_type().is_dir() {
-            true => FileType::Directory,
-            false => FileType::File,
+        let _file_type = if metadata.file_type().is_dir() {
+            FileType::Directory
+        } else {
+            FileType::File
         };
         let _link_type = match symlink_metadata.file_type().is_symlink() {
             true => {

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -4,4 +4,4 @@ mod metadata;
 
 pub use self::dirlist::JoshutoDirList;
 pub use self::entry::JoshutoDirEntry;
-pub use self::metadata::{FileType, JoshutoMetadata};
+pub use self::metadata::{FileType, JoshutoMetadata, LinkType};

--- a/src/ui/widgets/mod.rs
+++ b/src/ui/widgets/mod.rs
@@ -9,7 +9,7 @@ mod tui_topbar;
 mod tui_worker;
 
 pub use self::tui_dirlist::TuiDirList;
-pub use self::tui_dirlist_detailed::{print_file_name, TuiDirListDetailed};
+pub use self::tui_dirlist_detailed::{trim_file_label, TuiDirListDetailed};
 pub use self::tui_footer::TuiFooter;
 pub use self::tui_menu::TuiMenu;
 pub use self::tui_prompt::TuiPrompt;

--- a/src/ui/widgets/tui_dirlist.rs
+++ b/src/ui/widgets/tui_dirlist.rs
@@ -4,11 +4,9 @@ use tui::style::{Color, Modifier, Style};
 use tui::widgets::Widget;
 use unicode_width::UnicodeWidthStr;
 
-use crate::fs::{FileType, JoshutoDirEntry, JoshutoDirList};
-use crate::ui::widgets::print_file_name;
+use crate::fs::{JoshutoDirEntry, JoshutoDirList};
+use crate::ui::widgets::trim_file_label;
 use crate::util::style;
-
-const ELLIPSIS: &str = "…";
 
 pub struct TuiDirList<'a> {
     dirlist: &'a JoshutoDirList,
@@ -80,14 +78,10 @@ fn print_entry(
 ) {
     let name = entry.label();
     let name_width = name.width();
-
-    match entry.metadata.file_type() {
-        FileType::Directory => {
-            buf.set_stringn(x, y, name, drawing_width, style);
-            if name_width > drawing_width {
-                buf.set_string(x + drawing_width as u16 - 1, y, ELLIPSIS, style);
-            }
-        }
-        _ => print_file_name(buf, (x, y), name, style, drawing_width),
-    }
+    let label = if name_width > drawing_width {
+        trim_file_label(name, drawing_width)
+    } else {
+        name.to_string()
+    };
+    buf.set_string(x, y, label, style);
 }

--- a/src/ui/widgets/tui_dirlist_detailed.rs
+++ b/src/ui/widgets/tui_dirlist_detailed.rs
@@ -219,58 +219,57 @@ mod test_factor_labels {
             )
         );
     }
+}
+
+#[cfg(test)]
+mod test_trim_file_label {
+    use super::trim_file_label;
 
     #[test]
     fn dotfiles_get_an_ellipsis_at_the_end_if_they_dont_fit() {
-        let left = ".joshuto";
-        assert_eq!(
-            (".jos…".to_string(), "".to_string()),
-            factor_labels_for_entry(left, "".to_string(), 5)
-        );
+        let label = ".joshuto";
+        assert_eq!(".jos…".to_string(), trim_file_label(label, 5));
     }
 
     #[test]
     fn dotless_files_get_an_ellipsis_at_the_end_if_they_dont_fit() {
-        let left = "Desktop";
-        assert_eq!(
-            ("Desk…".to_string(), "".to_string()),
-            factor_labels_for_entry(left, "".to_string(), 5)
-        );
+        let label = "Desktop";
+        assert_eq!("Desk…".to_string(), trim_file_label(label, 5));
     }
 
     #[test]
     fn if_the_extension_doesnt_fit_just_an_ellipses_is_shown() {
-        let left = "foo.ext";
-        assert_eq!(
-            ("…".to_string(), "".to_string()),
-            factor_labels_for_entry(left, "".to_string(), 2)
-        );
+        let label = "foo.ext";
+        assert_eq!("…".to_string(), trim_file_label(label, 2));
     }
 
     #[test]
     fn if_just_the_extension_fits_its_shown_with_an_ellipsis_instead_of_a_dot() {
         let left = "foo.ext";
-        assert_eq!(
-            ("…ext".to_string(), "".to_string()),
-            factor_labels_for_entry(left, "".to_string(), 4)
-        );
+        assert_eq!("…ext".to_string(), trim_file_label(left, 4));
     }
 
     #[test]
     fn if_the_extension_fits_the_stem_is_truncated_with_an_appended_ellipsis_1() {
         let left = "foo.ext";
-        assert_eq!(
-            ("….ext".to_string(), "".to_string()),
-            factor_labels_for_entry(left, "".to_string(), 5)
-        );
+        assert_eq!("….ext".to_string(), trim_file_label(left, 5));
     }
 
     #[test]
     fn if_the_extension_fits_the_stem_is_truncated_with_an_appended_ellipsis_2() {
         let left = "foo.ext";
-        assert_eq!(
-            ("f….ext".to_string(), "".to_string()),
-            factor_labels_for_entry(left, "".to_string(), 6)
-        );
+        assert_eq!("f….ext".to_string(), trim_file_label(left, 6));
+    }
+
+    #[test]
+    fn if_the_name_is_truncated_after_a_full_width_character_the_ellipsis_is_shown_correctly() {
+        let left = "🌕🌕🌕";
+        assert_eq!("🌕…".to_string(), trim_file_label(left, 4));
+    }
+
+    #[test]
+    fn if_the_name_is_truncated_within_a_full_width_character_the_ellipsis_is_shown_correctly() {
+        let left = "🌕🌕🌕";
+        assert_eq!("🌕🌕…".to_string(), trim_file_label(left, 5));
     }
 }

--- a/src/ui/widgets/tui_dirlist_detailed.rs
+++ b/src/ui/widgets/tui_dirlist_detailed.rs
@@ -2,12 +2,12 @@ use tui::buffer::Buffer;
 use tui::layout::Rect;
 use tui::style::{Color, Modifier, Style};
 use tui::widgets::Widget;
-use unicode_width::UnicodeWidthStr;
 
 use crate::fs::{FileType, JoshutoDirEntry, JoshutoDirList, LinkType};
 use crate::util::format;
-use crate::util::string::truncate_by_char;
+use crate::util::string::UnicodeTruncate;
 use crate::util::style;
+use unicode_width::UnicodeWidthStr;
 
 const MIN_LEFT_LABEL_WIDTH: i32 = 15;
 
@@ -142,7 +142,7 @@ pub fn trim_file_label(name: &str, drawing_width: usize) -> String {
         String::from("")
     } else if stem.is_empty() || extension.is_empty() {
         let full = format!("{}{}", stem, extension);
-        let mut truncated = truncate_by_char(&full, drawing_width - 1);
+        let mut truncated = full.trunc(drawing_width - 1);
         truncated.push_str(ELLIPSIS);
         truncated
     } else {
@@ -154,7 +154,7 @@ pub fn trim_file_label(name: &str, drawing_width: usize) -> String {
             extension.to_string().replacen('.', ELLIPSIS, 1)
         } else {
             let stem_width = drawing_width - ext_width;
-            let truncated_stem = truncate_by_char(&stem.to_string(), stem_width - 1);
+            let truncated_stem = stem.trunc(stem_width - 1);
             format!("{}{}{}", truncated_stem, ELLIPSIS, extension)
         }
     }

--- a/src/ui/widgets/tui_dirlist_detailed.rs
+++ b/src/ui/widgets/tui_dirlist_detailed.rs
@@ -85,8 +85,8 @@ fn print_entry(
         FileType::File => format::file_size_to_string(entry.metadata.len()),
     };
     let symlink_string = match entry.metadata.link_type() {
-        LinkType::Normal => String::from(""),
-        LinkType::Symlink(_) => String::from("-> "),
+        LinkType::Normal => "",
+        LinkType::Symlink(_) => "-> ",
     };
     let left_label_original = entry.label();
     let right_label_original = format!(" {}{}", symlink_string, size_string);

--- a/src/ui/widgets/tui_dirlist_detailed.rs
+++ b/src/ui/widgets/tui_dirlist_detailed.rs
@@ -4,7 +4,7 @@ use tui::style::{Color, Modifier, Style};
 use tui::widgets::Widget;
 use unicode_width::UnicodeWidthStr;
 
-use crate::fs::{FileType, JoshutoDirEntry, JoshutoDirList};
+use crate::fs::{FileType, JoshutoDirEntry, JoshutoDirList, LinkType};
 use crate::util::format;
 use crate::util::style;
 
@@ -81,27 +81,12 @@ fn print_entry(
     drawing_width: usize,
 ) {
     let name = entry.label();
-    let name_width = name.width();
-
     match entry.metadata.file_type() {
         FileType::Directory => {
+            let name_width = name.width();
             buf.set_stringn(x, y, name, drawing_width, style);
             if name_width > drawing_width {
                 buf.set_string(x + drawing_width as u16 - 1, y, ELLIPSIS, style);
-            }
-        }
-        FileType::Symlink(_) => {
-            if drawing_width < SYMLINK_WIDTH {
-                return;
-            }
-            let file_drawing_width = drawing_width - SYMLINK_WIDTH;
-
-            print_file_name(buf, (x, y), name, style, file_drawing_width);
-
-            // print arrow
-            buf.set_string(x + file_drawing_width as u16, y, "->", style);
-            if name_width >= file_drawing_width {
-                buf.set_string(x + file_drawing_width as u16 - 1, y, ELLIPSIS, style);
             }
         }
         FileType::File => {
@@ -110,7 +95,7 @@ fn print_entry(
             }
             let file_drawing_width = drawing_width - FILE_SIZE_WIDTH;
 
-            print_file_name(buf, (x, y), name, style, file_drawing_width);
+            print_file_name(buf, (x, y), &name, style, file_drawing_width);
 
             // print file size
             let file_size_string = format::file_size_to_string(entry.metadata.len());
@@ -122,6 +107,23 @@ fn print_entry(
                 style,
             );
         }
+    }
+    match entry.metadata.link_type() {
+        LinkType::Symlink(_) => {
+            //  if drawing_width < SYMLINK_WIDTH {
+            //      return;
+            //  }
+            //  let file_drawing_width = drawing_width - SYMLINK_WIDTH;
+
+            //  print_file_name(buf, (x, y), name, style, file_drawing_width);
+
+            // print arrow
+            buf.set_string(x + drawing_width as u16 - 2, y, "->", style);
+            // if name_width >= file_drawing_width {
+            //     buf.set_string(x + file_drawing_width as u16 - 1, y, ELLIPSIS, style);
+            // }
+        }
+        LinkType::Normal => {}
     }
 }
 

--- a/src/ui/widgets/tui_dirlist_detailed.rs
+++ b/src/ui/widgets/tui_dirlist_detailed.rs
@@ -6,10 +6,10 @@ use unicode_width::UnicodeWidthStr;
 
 use crate::fs::{FileType, JoshutoDirEntry, JoshutoDirList, LinkType};
 use crate::util::format;
+use crate::util::string::truncate_by_char;
 use crate::util::style;
 
-const FILE_SIZE_WIDTH: usize = 8;
-const SYMLINK_WIDTH: usize = 4;
+const MIN_LEFT_LABEL_WIDTH: i32 = 15;
 
 const ELLIPSIS: &str = "…";
 
@@ -80,115 +80,197 @@ fn print_entry(
     (x, y): (u16, u16),
     drawing_width: usize,
 ) {
-    let name = entry.label();
-    match entry.metadata.file_type() {
-        FileType::Directory => {
-            let name_width = name.width();
-            buf.set_stringn(x, y, name, drawing_width, style);
-            if name_width > drawing_width {
-                buf.set_string(x + drawing_width as u16 - 1, y, ELLIPSIS, style);
-            }
+    let size_string = match entry.metadata.file_type() {
+        FileType::Directory => String::from(""),
+        FileType::File => format::file_size_to_string(entry.metadata.len()),
+    };
+    let symlink_string = match entry.metadata.link_type() {
+        LinkType::Normal => String::from(""),
+        LinkType::Symlink(_) => String::from("-> "),
+    };
+    let left_label_original = entry.label();
+    let right_label_original = format!(" {}{}", symlink_string, size_string);
+    let (left_label, right_label) =
+        factor_labels_for_entry(left_label_original, right_label_original, drawing_width);
+    let right_width = right_label.width();
+    buf.set_stringn(x, y, left_label, drawing_width, style);
+    buf.set_stringn(
+        x + drawing_width as u16 - right_width as u16,
+        y,
+        right_label,
+        drawing_width,
+        style,
+    );
+}
+
+fn factor_labels_for_entry(
+    left_label_original: &str,
+    right_label_original: String,
+    drawing_width: usize,
+) -> (String, String) {
+    let left_width_remainder = drawing_width as i32 - right_label_original.width() as i32;
+    let width_remainder = left_width_remainder as i32 - left_label_original.width() as i32;
+    if width_remainder >= 0 {
+        (
+            left_label_original.to_string(),
+            right_label_original.to_string(),
+        )
+    } else {
+        if left_label_original.width() <= drawing_width {
+            (left_label_original.to_string(), "".to_string())
+        } else if left_width_remainder < MIN_LEFT_LABEL_WIDTH {
+            (
+                trim_file_label(left_label_original, drawing_width),
+                "".to_string(),
+            )
+        } else {
+            (
+                trim_file_label(left_label_original, left_width_remainder as usize),
+                right_label_original.to_string(),
+            )
         }
-        FileType::File => {
-            if drawing_width < FILE_SIZE_WIDTH {
-                return;
-            }
-            let file_drawing_width = drawing_width - FILE_SIZE_WIDTH;
-
-            print_file_name(buf, (x, y), &name, style, file_drawing_width);
-
-            // print file size
-            let file_size_string = format::file_size_to_string(entry.metadata.len());
-            buf.set_string(x + file_drawing_width as u16, y, " ", style);
-            buf.set_string(
-                x + file_drawing_width as u16 + 1,
-                y,
-                file_size_string,
-                style,
-            );
-        }
-    }
-    match entry.metadata.link_type() {
-        LinkType::Symlink(_) => {
-            //  if drawing_width < SYMLINK_WIDTH {
-            //      return;
-            //  }
-            //  let file_drawing_width = drawing_width - SYMLINK_WIDTH;
-
-            //  print_file_name(buf, (x, y), name, style, file_drawing_width);
-
-            // print arrow
-            buf.set_string(x + drawing_width as u16 - 2, y, "->", style);
-            // if name_width >= file_drawing_width {
-            //     buf.set_string(x + file_drawing_width as u16 - 1, y, ELLIPSIS, style);
-            // }
-        }
-        LinkType::Normal => {}
     }
 }
 
-pub fn print_file_name(
-    buf: &mut Buffer,
-    (x, y): (u16, u16),
-    name: &str,
-    style: Style,
-    drawing_width: usize,
-) {
+pub fn trim_file_label(name: &str, drawing_width: usize) -> String {
+    // pre-condition: string name is longer than width
     let (stem, extension) = match name.rfind('.') {
         None => (name, ""),
         Some(i) => name.split_at(i),
     };
-    if stem.is_empty() {
-        let ext_width = extension.width();
-        buf.set_stringn(x, y, extension, drawing_width, style);
-        if ext_width > drawing_width {
-            buf.set_string(x + drawing_width as u16 - 1, y, ELLIPSIS, style);
-        }
-    } else if extension.is_empty() {
-        let stem_width = stem.width();
-        buf.set_stringn(x, y, stem, drawing_width, style);
-        if stem_width > drawing_width {
-            buf.set_string(x + drawing_width as u16 - 1, y, ELLIPSIS, style);
-        }
+    if drawing_width < 1 {
+        String::from("")
+    } else if stem.is_empty() || extension.is_empty() {
+        let full = format!("{}{}", stem, extension);
+        let mut truncated = truncate_by_char(&full, drawing_width - 1);
+        truncated.push_str(ELLIPSIS);
+        truncated
     } else {
-        if stem.is_empty() {
-            let ext_width = extension.width();
-            buf.set_stringn(x, y, extension, drawing_width, style);
-            if ext_width > drawing_width {
-                buf.set_string(x + drawing_width as u16 - 1, y, ELLIPSIS, style);
-            }
-        } else if extension.is_empty() {
-            let stem_width = stem.width();
-            buf.set_stringn(x, y, stem, drawing_width, style);
-            if stem_width > drawing_width {
-                buf.set_string(x + drawing_width as u16 - 1, y, ELLIPSIS, style);
-            }
+        let ext_width = extension.width();
+        if ext_width > drawing_width {
+            // file ext does not fit
+            ELLIPSIS.to_string()
+        } else if ext_width == drawing_width {
+            extension.to_string().replacen('.', ELLIPSIS, 1)
         } else {
-            let stem_width = stem.width();
-            let ext_width = extension.width();
-            if stem_width + ext_width <= drawing_width {
-                // file stem and extension fits
-                buf.set_stringn(x, y, stem, drawing_width, style);
-                buf.set_string(x + stem_width as u16, y, extension, style);
-            } else if ext_width > drawing_width {
-                // file ext does not fit
-                buf.set_string(x, y, ELLIPSIS, style);
-            } else {
-                buf.set_stringn(x, y, stem, drawing_width, style);
-                // file ext fits, but file stem does not
-                let ext_start_idx = if drawing_width < ext_width {
-                    0
-                } else {
-                    (drawing_width - ext_width) as u16
-                };
-                buf.set_string(x + ext_start_idx, y, extension, style);
-                let ext_start_idx = if ext_start_idx > 0 {
-                    ext_start_idx - 1
-                } else {
-                    0
-                };
-                buf.set_string(x + ext_start_idx, y, ELLIPSIS, style);
-            }
+            let stem_width = drawing_width - ext_width;
+            let truncated_stem = truncate_by_char(&stem.to_string(), stem_width - 1);
+            format!("{}{}{}", truncated_stem, ELLIPSIS, extension)
         }
+    }
+}
+
+#[cfg(test)]
+mod test_factor_labels {
+    use super::{factor_labels_for_entry, MIN_LEFT_LABEL_WIDTH};
+
+    #[test]
+    fn both_labels_empty_if_drawing_width_zero() {
+        let left = "foo.ext";
+        let right = "right";
+        assert_eq!(
+            ("".to_string(), "".to_string()),
+            factor_labels_for_entry(left, right.to_string(), 0)
+        );
+    }
+
+    #[test]
+    fn nothing_changes_if_all_labels_fit_easily() {
+        let left = "foo.ext";
+        let right = "right";
+        assert_eq!(
+            (left.to_string(), right.to_string()),
+            factor_labels_for_entry(left, right.to_string(), 20)
+        );
+    }
+
+    #[test]
+    fn nothing_changes_if_all_labels_just_fit() {
+        let left = "foo.ext";
+        let right = "right";
+        assert_eq!(
+            (left.to_string(), right.to_string()),
+            factor_labels_for_entry(left, right.to_string(), 12)
+        );
+    }
+
+    #[test]
+    fn right_label_omitted_if_left_label_would_need_to_be_shortened_below_min_left_label_width() {
+        let left = "foobarbazfo.ext";
+        let right = "right";
+        assert!(left.chars().count() as i32 == MIN_LEFT_LABEL_WIDTH);
+        assert_eq!(
+            (left.to_string(), "".to_string()),
+            factor_labels_for_entry(left, right.to_string(), MIN_LEFT_LABEL_WIDTH as usize)
+        );
+    }
+
+    #[test]
+    fn right_label_is_kept_if_left_label_is_not_shortened_below_min_left_label_width() {
+        let left = "foobarbazfoobarbaz.ext";
+        let right = "right";
+        assert!(left.chars().count() as i32 > MIN_LEFT_LABEL_WIDTH + right.chars().count() as i32);
+        assert_eq!(
+            ("foobarbazf….ext".to_string(), right.to_string()),
+            factor_labels_for_entry(
+                left,
+                right.to_string(),
+                MIN_LEFT_LABEL_WIDTH as usize + right.chars().count()
+            )
+        );
+    }
+
+    #[test]
+    fn dotfiles_get_an_ellipsis_at_the_end_if_they_dont_fit() {
+        let left = ".joshuto";
+        assert_eq!(
+            (".jos…".to_string(), "".to_string()),
+            factor_labels_for_entry(left, "".to_string(), 5)
+        );
+    }
+
+    #[test]
+    fn dotless_files_get_an_ellipsis_at_the_end_if_they_dont_fit() {
+        let left = "Desktop";
+        assert_eq!(
+            ("Desk…".to_string(), "".to_string()),
+            factor_labels_for_entry(left, "".to_string(), 5)
+        );
+    }
+
+    #[test]
+    fn if_the_extension_doesnt_fit_just_an_ellipses_is_shown() {
+        let left = "foo.ext";
+        assert_eq!(
+            ("…".to_string(), "".to_string()),
+            factor_labels_for_entry(left, "".to_string(), 2)
+        );
+    }
+
+    #[test]
+    fn if_just_the_extension_fits_its_shown_with_an_ellipsis_instead_of_a_dot() {
+        let left = "foo.ext";
+        assert_eq!(
+            ("…ext".to_string(), "".to_string()),
+            factor_labels_for_entry(left, "".to_string(), 4)
+        );
+    }
+
+    #[test]
+    fn if_the_extension_fits_the_stem_is_truncated_with_an_appended_ellipsis_1() {
+        let left = "foo.ext";
+        assert_eq!(
+            ("….ext".to_string(), "".to_string()),
+            factor_labels_for_entry(left, "".to_string(), 5)
+        );
+    }
+
+    #[test]
+    fn if_the_extension_fits_the_stem_is_truncated_with_an_appended_ellipsis_2() {
+        let left = "foo.ext";
+        assert_eq!(
+            ("f….ext".to_string(), "".to_string()),
+            factor_labels_for_entry(left, "".to_string(), 6)
+        );
     }
 }

--- a/src/ui/widgets/tui_footer.rs
+++ b/src/ui/widgets/tui_footer.rs
@@ -4,7 +4,7 @@ use tui::style::{Color, Style};
 use tui::text::{Span, Spans};
 use tui::widgets::{Paragraph, Widget};
 
-use crate::fs::{FileType, JoshutoDirList};
+use crate::fs::{JoshutoDirList, LinkType};
 use crate::util::format;
 use crate::util::unix;
 
@@ -41,7 +41,7 @@ impl<'a> Widget for TuiFooter<'a> {
                     Span::raw(size_str),
                 ];
 
-                if let FileType::Symlink(s) = entry.metadata.file_type() {
+                if let LinkType::Symlink(s) = entry.metadata.link_type() {
                     text.push(Span::styled(" -> ", mode_style));
                     text.push(Span::styled(s, mode_style));
                 }

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -10,6 +10,7 @@ pub mod name_resolution;
 pub mod search;
 pub mod select;
 pub mod sort;
+pub mod string;
 pub mod style;
 pub mod to_string;
 pub mod unix;

--- a/src/util/string.rs
+++ b/src/util/string.rs
@@ -1,0 +1,20 @@
+#[inline(always)]
+pub fn truncate_by_char(s: &String, max_chars: usize) -> String {
+    match s.char_indices().nth(max_chars) {
+        None => String::from(s),
+        Some((idx, _)) => s[..idx].to_string(),
+    }
+}
+
+#[cfg(test)]
+mod string_truncation {
+    use super::truncate_by_char;
+
+    #[test]
+    fn truncate_despite_several_multibyte_chars() {
+        assert_eq!(
+            truncate_by_char(&String::from("✗a⮋b⬎"), 3),
+            String::from("✗a⮋")
+        );
+    }
+}

--- a/src/util/string.rs
+++ b/src/util/string.rs
@@ -1,20 +1,67 @@
-#[inline(always)]
-pub fn truncate_by_char(s: &String, max_chars: usize) -> String {
-    match s.char_indices().nth(max_chars) {
-        None => String::from(s),
-        Some((idx, _)) => s[..idx].to_string(),
+use unicode_segmentation::UnicodeSegmentation;
+use unicode_width::UnicodeWidthStr;
+
+///Truncates a string to width, less or equal to the specified one.
+///
+///In case the point of truncation falls into a full-width character,
+///the returned string will be shorter than the given `width`.
+///Otherwise, it will be equal.
+pub trait UnicodeTruncate {
+    fn trunc(&self, width: usize) -> String;
+}
+
+impl UnicodeTruncate for str {
+    #[inline]
+    fn trunc(&self, width: usize) -> String {
+        if self.width() <= width {
+            String::from(self)
+        } else {
+            let mut length: usize = 0;
+            let mut result = String::new();
+            for grapheme in self.graphemes(true) {
+                let grapheme_length = grapheme.width();
+                length += grapheme_length;
+                if length > width {
+                    break;
+                };
+                result.push_str(grapheme);
+            }
+            result
+        }
     }
 }
 
 #[cfg(test)]
-mod string_truncation {
-    use super::truncate_by_char;
+mod tests_trunc {
+    use super::UnicodeTruncate;
 
     #[test]
-    fn truncate_despite_several_multibyte_chars() {
-        assert_eq!(
-            truncate_by_char(&String::from("✗a⮋b⬎"), 3),
-            String::from("✗a⮋")
-        );
+    fn truncate_correct_despite_several_multibyte_chars() {
+        assert_eq!(String::from("r͂o͒͜w̾").trunc(2), String::from("r͂o͒͜"));
+    }
+
+    #[test]
+    fn truncate_at_end_returns_complete_string() {
+        assert_eq!(String::from("r͂o͒͜w̾").trunc(3), String::from("r͂o͒͜w̾"));
+    }
+
+    #[test]
+    fn truncate_behind_end_returns_complete_string() {
+        assert_eq!(String::from("r͂o͒͜w̾").trunc(4), String::from("r͂o͒͜w̾"));
+    }
+
+    #[test]
+    fn truncate_at_zero_returns_empty_string() {
+        assert_eq!(String::from("r͂o͒͜w̾").trunc(0), String::from(""));
+    }
+
+    #[test]
+    fn truncate_correct_despite_fullwidth_character() {
+        assert_eq!(String::from("a🌕bc").trunc(4), String::from("a🌕b"));
+    }
+
+    #[test]
+    fn truncate_within_fullwidth_character_truncates_before_the_character() {
+        assert_eq!(String::from("a🌕").trunc(2), String::from("a"));
     }
 }

--- a/src/util/style.rs
+++ b/src/util/style.rs
@@ -26,27 +26,28 @@ pub fn entry_style(entry: &JoshutoDirEntry) -> Style {
                     .fg(THEME_T.directory.fg)
                     .bg(THEME_T.directory.bg)
                     .add_modifier(THEME_T.directory.modifier),
-                FileType::File => {
-                    if unix::is_executable(metadata.mode) {
-                        Style::default()
-                            .fg(THEME_T.executable.fg)
-                            .bg(THEME_T.executable.bg)
-                            .add_modifier(THEME_T.executable.modifier)
-                    } else {
-                        match entry.file_path().extension() {
-                            None => Style::default(),
-                            Some(os_str) => match os_str.to_str() {
-                                None => Style::default(),
-                                Some(s) => match THEME_T.ext.get(s) {
-                                    None => Style::default(),
-                                    Some(t) => {
-                                        Style::default().fg(t.fg).bg(t.bg).add_modifier(t.modifier)
-                                    }
-                                },
-                            },
-                        }
-                    }
-                }
+                FileType::File => file_style(entry),
+            },
+        }
+    }
+}
+
+fn file_style(entry: &JoshutoDirEntry) -> Style {
+    let metadata = &entry.metadata;
+    if unix::is_executable(metadata.mode) {
+        Style::default()
+            .fg(THEME_T.executable.fg)
+            .bg(THEME_T.executable.bg)
+            .add_modifier(THEME_T.executable.modifier)
+    } else {
+        match entry.file_path().extension() {
+            None => Style::default(),
+            Some(os_str) => match os_str.to_str() {
+                None => Style::default(),
+                Some(s) => match THEME_T.ext.get(s) {
+                    None => Style::default(),
+                    Some(t) => Style::default().fg(t.fg).bg(t.bg).add_modifier(t.modifier),
+                },
             },
         }
     }

--- a/src/util/style.rs
+++ b/src/util/style.rs
@@ -1,6 +1,6 @@
 use tui::style::Style;
 
-use crate::fs::{FileType, JoshutoDirEntry};
+use crate::fs::{FileType, JoshutoDirEntry, LinkType};
 use crate::util::unix;
 
 use crate::THEME_T;
@@ -8,33 +8,46 @@ use crate::THEME_T;
 pub fn entry_style(entry: &JoshutoDirEntry) -> Style {
     let metadata = &entry.metadata;
     let filetype = &metadata.file_type();
+    let linktype = &metadata.link_type();
 
-    match filetype {
-        _ if entry.is_selected() => Style::default()
+    if entry.is_selected() {
+        Style::default()
             .fg(THEME_T.selection.fg)
             .bg(THEME_T.selection.bg)
-            .add_modifier(THEME_T.selection.modifier),
-        FileType::Directory => Style::default()
-            .fg(THEME_T.directory.fg)
-            .bg(THEME_T.directory.bg)
-            .add_modifier(THEME_T.directory.modifier),
-        FileType::Symlink(_) => Style::default()
-            .fg(THEME_T.link.fg)
-            .bg(THEME_T.link.bg)
-            .add_modifier(THEME_T.link.modifier),
-        _ if unix::is_executable(metadata.mode) => Style::default()
-            .fg(THEME_T.executable.fg)
-            .bg(THEME_T.executable.bg)
-            .add_modifier(THEME_T.executable.modifier),
-        _ => match entry.file_path().extension() {
-            None => Style::default(),
-            Some(os_str) => match os_str.to_str() {
-                None => Style::default(),
-                Some(s) => match THEME_T.ext.get(s) {
-                    None => Style::default(),
-                    Some(t) => Style::default().fg(t.fg).bg(t.bg).add_modifier(t.modifier),
-                },
+            .add_modifier(THEME_T.selection.modifier)
+    } else {
+        match linktype {
+            LinkType::Symlink(_) => Style::default()
+                .fg(THEME_T.link.fg)
+                .bg(THEME_T.link.bg)
+                .add_modifier(THEME_T.link.modifier),
+            LinkType::Normal => match filetype {
+                FileType::Directory => Style::default()
+                    .fg(THEME_T.directory.fg)
+                    .bg(THEME_T.directory.bg)
+                    .add_modifier(THEME_T.directory.modifier),
+                FileType::File => {
+                    if unix::is_executable(metadata.mode) {
+                        Style::default()
+                            .fg(THEME_T.executable.fg)
+                            .bg(THEME_T.executable.bg)
+                            .add_modifier(THEME_T.executable.modifier)
+                    } else {
+                        match entry.file_path().extension() {
+                            None => Style::default(),
+                            Some(os_str) => match os_str.to_str() {
+                                None => Style::default(),
+                                Some(s) => match THEME_T.ext.get(s) {
+                                    None => Style::default(),
+                                    Some(t) => {
+                                        Style::default().fg(t.fg).bg(t.bg).add_modifier(t.modifier)
+                                    }
+                                },
+                            },
+                        }
+                    }
+                }
             },
-        },
+        }
     }
 }


### PR DESCRIPTION
This PR is the first part of #71. It does not contain the directory size feature, but it includes:

* Show symlinked dirs like dirs, with a directory devicon
* Show size of target file for symlinked files in conbination with the “symlink arrow”
* Show permission flags of target file for symlinked files

This PR is much more invasive than I expected. Sorry for that. But when I started to combine the “symlink arrow” with the file size, one change led to the next. 

The massive change is mostly because of the calculation of the entry strings to display, which is now done in separate functions without using the `buf.set_stringn` method to handle the truncation of strings.

The good thing is that the code is more testable and easier to extend, for my feeling. A downside might be that the string truncation is based on characters. I dont't know how tui-rs handles that, but I guess it uses correct graphemes instead of just characters when using the `buf.set_stringn` function. I could use something like [unicode-segmentation](https://crates.io/crates/unicode-segmentation/1.7.1) instead to realize a more proper truncation.

Also, some refactoring for `pub fn entry_style` would be good, it really looks kind of ugly, I know.

Anyway, before putting more effort into this, I wanted to give a chance for feedback.