### PR TITLE
open command line with a colon

### DIFF
--- a/config/keymap.toml
+++ b/config/keymap.toml
@@ -161,6 +161,9 @@ keys = [ "=" ]
 command = ":"
 keys = [ ";" ]
 [[mapcommand]]
+command = ":"
+keys = [ ":" ]
+[[mapcommand]]
 command = ":mkdir "
 keys = [ "m", "k" ]
 [[mapcommand]]

--- a/src/config/keymap/keymapping.rs
+++ b/src/config/keymap/keymapping.rs
@@ -224,6 +224,10 @@ impl AppKeyMapping {
         let keys = [Event::Key(Key::Char(';'))];
         insert_keycommand(&mut m, cmd, &keys)?;
 
+        let cmd = KeyCommand::CommandLine("".to_string(), "".to_string());
+        let keys = [Event::Key(Key::Char(':'))];
+        insert_keycommand(&mut m, cmd, &keys)?;
+
         let cmd = KeyCommand::CommandLine("mkdir ".to_string(), "".to_string());
         let keys = [Event::Key(Key::Char('m')), Event::Key(Key::Char('k'))];
         insert_keycommand(&mut m, cmd, &keys)?;


### PR DESCRIPTION
Beside opening the command line with a semi-colon, it can be opened also
with a colon. The default key mapping has been adapted as well as the
keymap.toml configuration template.