### PR TITLE
show size of directories

### DIFF
--- a/src/fs/metadata.rs
+++ b/src/fs/metadata.rs
@@ -15,6 +15,7 @@ pub enum LinkType {
 #[derive(Clone, Debug)]
 pub struct JoshutoMetadata {
     _len: u64,
+    _directory_size: Option<usize>,
     _modified: time::SystemTime,
     _permissions: fs::Permissions,
     _file_type: FileType,
@@ -38,10 +39,10 @@ impl JoshutoMetadata {
         let _len = metadata.len();
         let _modified = metadata.modified()?;
         let _permissions = metadata.permissions();
-        let _file_type = if metadata.file_type().is_dir() {
-            FileType::Directory
+        let (_file_type, _directory_size) = if metadata.file_type().is_dir() {
+            (FileType::Directory, Some(fs::read_dir(path)?.count()))
         } else {
-            FileType::File
+            (FileType::File, None)
         };
         let _link_type = match symlink_metadata.file_type().is_symlink() {
             true => {
@@ -66,6 +67,7 @@ impl JoshutoMetadata {
 
         Ok(Self {
             _len,
+            _directory_size,
             _modified,
             _permissions,
             _file_type,
@@ -81,6 +83,10 @@ impl JoshutoMetadata {
 
     pub fn len(&self) -> u64 {
         self._len
+    }
+
+    pub fn directory_size(&self) -> Option<usize> {
+        self._directory_size
     }
 
     pub fn modified(&self) -> time::SystemTime {

--- a/src/ui/widgets/tui_dirlist_detailed.rs
+++ b/src/ui/widgets/tui_dirlist_detailed.rs
@@ -81,7 +81,11 @@ fn print_entry(
     drawing_width: usize,
 ) {
     let size_string = match entry.metadata.file_type() {
-        FileType::Directory => String::from(""),
+        FileType::Directory => entry
+            .metadata
+            .directory_size()
+            .expect("Directory doesn't have size")
+            .to_string(),
         FileType::File => format::file_size_to_string(entry.metadata.len()),
     };
     let symlink_string = match entry.metadata.link_type() {


### PR DESCRIPTION
The middle column shows the size of directories in terms of contained
files and sub-directories in the right label for each entry.

Invalid symlinks and hidden files/dirs are included in the count.