### PR TITLE
highlight invalid symlinks

### DIFF
--- a/config/theme.toml
+++ b/config/theme.toml
@@ -20,6 +20,10 @@ bold = true
 fg = "light_cyan"
 bold = true
 
+[link_invalid]
+fg = "red"
+bold = true
+
 [socket]
 fg = "light_magenta"
 bold = true

--- a/src/config/theme/app_theme.rs
+++ b/src/config/theme/app_theme.rs
@@ -19,6 +19,8 @@ pub struct RawAppTheme {
     #[serde(default)]
     pub link: RawAppStyle,
     #[serde(default)]
+    pub link_invalid: RawAppStyle,
+    #[serde(default)]
     pub socket: RawAppStyle,
     #[serde(default)]
     pub ext: HashMap<String, RawAppStyle>,
@@ -32,6 +34,7 @@ impl std::default::Default for RawAppTheme {
             directory: RawAppStyle::default(),
             executable: RawAppStyle::default(),
             link: RawAppStyle::default(),
+            link_invalid: RawAppStyle::default(),
             socket: RawAppStyle::default(),
             ext: HashMap::default(),
         }
@@ -45,6 +48,7 @@ impl Flattenable<AppTheme> for RawAppTheme {
         let regular = self.regular.to_style_theme();
         let directory = self.directory.to_style_theme();
         let link = self.link.to_style_theme();
+        let link_invalid = self.link_invalid.to_style_theme();
         let socket = self.socket.to_style_theme();
         let ext: HashMap<String, AppStyle> = self
             .ext
@@ -61,6 +65,7 @@ impl Flattenable<AppTheme> for RawAppTheme {
             regular,
             directory,
             link,
+            link_invalid,
             socket,
             ext,
         }
@@ -74,6 +79,7 @@ pub struct AppTheme {
     pub directory: AppStyle,
     pub executable: AppStyle,
     pub link: AppStyle,
+    pub link_invalid: AppStyle,
     pub socket: AppStyle,
     pub ext: HashMap<String, AppStyle>,
 }
@@ -99,6 +105,9 @@ impl std::default::Default for AppTheme {
         let link = AppStyle::default()
             .set_fg(Color::LightCyan)
             .insert(Modifier::BOLD);
+        let link_invalid = AppStyle::default()
+            .set_fg(Color::Red)
+            .insert(Modifier::BOLD);
         let socket = AppStyle::default()
             .set_fg(Color::LightMagenta)
             .insert(Modifier::BOLD);
@@ -110,6 +119,7 @@ impl std::default::Default for AppTheme {
             regular,
             directory,
             link,
+            link_invalid,
             socket,
             ext,
         }

--- a/src/fs/metadata.rs
+++ b/src/fs/metadata.rs
@@ -9,7 +9,7 @@ pub enum FileType {
 #[derive(Clone, Debug)]
 pub enum LinkType {
     Normal,
-    Symlink(String),
+    Symlink(String, bool), // link target, link validity
 }
 
 #[derive(Clone, Debug)]
@@ -52,18 +52,19 @@ impl JoshutoMetadata {
             _ => (FileType::File, None),
         };
 
-        let _link_type = match symlink_metadata.file_type().is_symlink() {
-            true => {
-                let mut link = "".to_string();
+        let _link_type = if symlink_metadata.file_type().is_symlink() {
+            let mut link = "".to_string();
 
-                if let Ok(path) = fs::read_link(path) {
-                    if let Some(s) = path.to_str() {
-                        link = s.to_string();
-                    }
+            if let Ok(path) = fs::read_link(path) {
+                if let Some(s) = path.to_str() {
+                    link = s.to_string();
                 }
-                LinkType::Symlink(link)
             }
-            false => LinkType::Normal,
+
+            let exists = path.exists();
+            LinkType::Symlink(link, exists)
+        } else {
+            LinkType::Normal
         };
 
         #[cfg(unix)]

--- a/src/ui/widgets/tui_dirlist_detailed.rs
+++ b/src/ui/widgets/tui_dirlist_detailed.rs
@@ -90,7 +90,7 @@ fn print_entry(
     };
     let symlink_string = match entry.metadata.link_type() {
         LinkType::Normal => "",
-        LinkType::Symlink(_) => "-> ",
+        LinkType::Symlink(_, _) => "-> ",
     };
     let left_label_original = entry.label();
     let right_label_original = format!(" {}{} ", symlink_string, size_string);

--- a/src/ui/widgets/tui_footer.rs
+++ b/src/ui/widgets/tui_footer.rs
@@ -7,6 +7,7 @@ use tui::widgets::{Paragraph, Widget};
 use crate::fs::{JoshutoDirList, LinkType};
 use crate::util::format;
 use crate::util::unix;
+use crate::THEME_T;
 
 pub struct TuiFooter<'a> {
     dirlist: &'a JoshutoDirList,
@@ -41,9 +42,20 @@ impl<'a> Widget for TuiFooter<'a> {
                     Span::raw(size_str),
                 ];
 
-                if let LinkType::Symlink(s, _) = entry.metadata.link_type() {
-                    text.push(Span::styled(" -> ", mode_style));
-                    text.push(Span::styled(s, mode_style));
+                if let LinkType::Symlink(target, valid) = entry.metadata.link_type() {
+                    let link_style = if *valid {
+                        Style::default()
+                            .fg(THEME_T.link.fg)
+                            .bg(THEME_T.link.bg)
+                            .add_modifier(THEME_T.link.modifier)
+                    } else {
+                        Style::default()
+                            .fg(THEME_T.link_invalid.fg)
+                            .bg(THEME_T.link_invalid.bg)
+                            .add_modifier(THEME_T.link_invalid.modifier)
+                    };
+                    text.push(Span::styled(" -> ", link_style));
+                    text.push(Span::styled(target, link_style));
                 }
 
                 Paragraph::new(Spans::from(text)).render(area, buf);

--- a/src/ui/widgets/tui_footer.rs
+++ b/src/ui/widgets/tui_footer.rs
@@ -41,7 +41,7 @@ impl<'a> Widget for TuiFooter<'a> {
                     Span::raw(size_str),
                 ];
 
-                if let LinkType::Symlink(s) = entry.metadata.link_type() {
+                if let LinkType::Symlink(s, _) = entry.metadata.link_type() {
                     text.push(Span::styled(" -> ", mode_style));
                     text.push(Span::styled(s, mode_style));
                 }

--- a/src/util/style.rs
+++ b/src/util/style.rs
@@ -17,10 +17,14 @@ pub fn entry_style(entry: &JoshutoDirEntry) -> Style {
             .add_modifier(THEME_T.selection.modifier)
     } else {
         match linktype {
-            LinkType::Symlink(_) => Style::default()
+            LinkType::Symlink(_, true) => Style::default()
                 .fg(THEME_T.link.fg)
                 .bg(THEME_T.link.bg)
                 .add_modifier(THEME_T.link.modifier),
+            LinkType::Symlink(_, false) => Style::default()
+                .fg(THEME_T.link_invalid.fg)
+                .bg(THEME_T.link_invalid.bg)
+                .add_modifier(THEME_T.link_invalid.modifier),
             LinkType::Normal => match filetype {
                 FileType::Directory => Style::default()
                     .fg(THEME_T.directory.fg)


### PR DESCRIPTION
Dangling symlinks are shown with a separate style. `theme.toml` has been extended with a `[link_invalid]` section. The default style is red+bold.

Furthermore, the link target, which is shown in the footer for a selected symlink, uses either the “link” style or the ”link_invalid” style respectively.

Merge request for `dev` branch as I saw that a symlink related commit was already on that branch. 
We can close #71 then. :wink: 