### PR TITLE
version bump to 0.9.1 in Cargo.lock with cargo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -512,7 +512,7 @@ checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "joshuto"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "alphanumeric-sort",
  "chrono",


### PR DESCRIPTION
Hi there. I'm the maintainer of the [joshuto](https://ports.macports.org/port/joshuto/details/) port over at [MacPorts](https://www.macports.org).

MacPorts usually builds projects written in rust using the --frozen flag by first downloading the necessary dependencies. This way the cargo builds the project without access to the internet.

I noticed that the last two versions of joshuto have an incorrect Cargo.lock file in the tag. So I am forced to regenerate Cargo.lock and apply it as the patch. My request would be to regenerate Cargo.lock before releasing the new version.

Thanks for this great project!