### PR TITLE
Add ANSI color codes support in file previews

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20e59b2ccb4c1ffbbf45af6f493e16ac65a66981c85664f1587816c0b08cd698"
 
 [[package]]
+name = "ansi-to-tui"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c3fb5747c9d1b444cb6c9f96c84d09a3f7ae9e1eb77f52ec45c8bf30a6e6bdf"
+dependencies = [
+ "tui",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -289,6 +298,7 @@ name = "joshuto"
 version = "0.9.1"
 dependencies = [
  "alphanumeric-sort",
+ "ansi-to-tui",
  "chrono",
  "colors-transform",
  "dirs-next",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ xdg = "^2"
 phf = { version = "^0", features = ["macros"], optional = true }
 trash = { version = "^1", optional = true }
 unicode-segmentation = "^1"
+ansi-to-tui = "0.4.1"
 
 [features]
 devicons = [ "phf" ]

--- a/src/ui/widgets/tui_file_preview.rs
+++ b/src/ui/widgets/tui_file_preview.rs
@@ -1,6 +1,7 @@
+use ansi_to_tui::ansi_to_text;
 use tui::buffer::Buffer;
 use tui::layout::Rect;
-use tui::style::Style;
+use tui::text::Text;
 use tui::widgets::Widget;
 
 use crate::fs::JoshutoDirEntry;
@@ -19,10 +20,9 @@ impl<'a> TuiFilePreview<'a> {
 
 impl<'a> Widget for TuiFilePreview<'a> {
     fn render(self, area: Rect, buf: &mut Buffer) {
-        let style = Style::default();
-        let area_width = area.width as usize;
-        for (y, s) in (area.y..area.y + area.height).zip(self.preview.output.as_str().split('\n')) {
-            buf.set_stringn(area.x, y, s, area_width, style);
+        let text: Text = ansi_to_text(self.preview.output.as_str().as_bytes().to_vec()).unwrap();
+        for (y, line) in (area.y..area.y + area.height).zip(text.lines) {
+            buf.set_spans(area.x, y, &line, area.width);
         }
     }
 }


### PR DESCRIPTION
Add ANSI color codes support in file preview using [ansi-to-tui](https://github.com/uttarayan21/ansi-to-tui) as suggested [here](https://github.com/fdehau/tui-rs/issues/304#issuecomment-827124643)

### Screenshot
![Screenshot_20211118_155938](https://user-images.githubusercontent.com/41364823/142427113-d8742c2f-9335-4c5d-997a-8ce72fdcc9b4.png)

### Example

In `preview.sh`
```bash
# file extension "json"
jq --color-output . "${path}" && exit 0
# mime type "text/*"
bat --color=always --style="plain" -- "${path}" && exit 0
```

using `highlight` doesn't seem to work :(

related #67