### PR TITLE
add line numbers

### DIFF
--- a/config/joshuto.toml
+++ b/config/joshuto.toml
@@ -12,6 +12,8 @@ show_hidden = false
 show_icons = true
 show_preview = true
 tilde_in_titlebar = true
+# no, absolute, relative
+line_nums = "no"
 
 [display.sort]
 # lexical, mtime, natural

--- a/config/joshuto.toml
+++ b/config/joshuto.toml
@@ -12,8 +12,8 @@ show_hidden = false
 show_icons = true
 show_preview = true
 tilde_in_titlebar = true
-# no, absolute, relative
-line_nums = "no"
+# none, absolute, relative
+line_number_style = "none"
 
 [display.sort]
 # lexical, mtime, natural

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,3 +4,4 @@ These docs should help you get set up and understand how Joshuto works.
 
  - [configuration](/docs/configuration/)
  - [contributing](/docs/contributing.md)
+ - [misc](/docs/misc.md)

--- a/docs/configuration/joshuto.toml.md
+++ b/docs/configuration/joshuto.toml.md
@@ -34,6 +34,11 @@ show_icons = true
 show_preview = true
 # Shorten /home/$USER to ~
 tilde_in_titlebar = true
+# Options include
+# - no
+# - absolute
+# - relative
+line_nums = "no"
 
 # Configurations related to file sorting
 [display.sort]

--- a/docs/configuration/joshuto.toml.md
+++ b/docs/configuration/joshuto.toml.md
@@ -35,10 +35,10 @@ show_preview = true
 # Shorten /home/$USER to ~
 tilde_in_titlebar = true
 # Options include
-# - no
+# - none
 # - absolute
 # - relative
-line_nums = "no"
+line_number_style = "none"
 
 # Configurations related to file sorting
 [display.sort]

--- a/docs/configuration/keymap.toml.md
+++ b/docs/configuration/keymap.toml.md
@@ -93,7 +93,7 @@ function joshuto() {
     - press `escape` to exit view
  - `toggle_hidden`: toggle hidden files
  - `line_nums`: switch displaying of entry numbers
-    - `line_nums 0` or `line_nums no`: disable displaying
+    - `line_nums 0` or `line_nums none`: disable displaying
     - `line_nums 1` or `line_nums absolute`: enable absolute numbers for each entry
     - `line_nums 2` or `line_nums relative`: enable numbers relative to selected entry
 

--- a/docs/configuration/keymap.toml.md
+++ b/docs/configuration/keymap.toml.md
@@ -92,6 +92,10 @@ function joshuto() {
  - `show_workers`: show the pending IO operations and the current progress
     - press `escape` to exit view
  - `toggle_hidden`: toggle hidden files
+ - `line_nums`: switch displaying of entry numbers
+    - `line_nums 0` or `line_nums no`: disable displaying
+    - `line_nums 1` or `line_nums absolute`: enable absolute numbers for each entry
+    - `line_nums 2` or `line_nums relative`: enable numbers relative to selected entry
 
 ## Navigation
  - `cursor_move_up`: moves the cursor up by x amount

--- a/docs/misc.md
+++ b/docs/misc.md
@@ -1,0 +1,10 @@
+## Numbered commands
+You can prefix some commands with a number. For this, just start entering
+a number and then press any key which is mapped to a command. Currently
+supported commands are:
+  - `cursor_move_up`: moves cursor up by number of lines you prefixed the
+    command with
+  - `cursor_move_down`: moves cursor down by number of lines you prefixed the
+    command with
+  - `g`: this is hard-coded, you cannot remap this command. Just enter a number
+    and then press `g` to jump to n'th line

--- a/src/commands/line_nums.rs
+++ b/src/commands/line_nums.rs
@@ -1,12 +1,16 @@
+use crate::config::option::LineNumberStyle;
 use crate::context::AppContext;
 use crate::error::JoshutoResult;
 
 use super::reload;
 
-pub fn switch_line_numbering(context: &mut AppContext, policy: u8) -> JoshutoResult<()> {
+pub fn switch_line_numbering(
+    context: &mut AppContext,
+    style: LineNumberStyle,
+) -> JoshutoResult<()> {
     context
         .config_mut()
         .display_options_mut()
-        .set_line_nums(policy);
+        .set_line_nums(style);
     reload::reload_dirlist(context)
 }

--- a/src/commands/line_nums.rs
+++ b/src/commands/line_nums.rs
@@ -1,0 +1,12 @@
+use crate::context::AppContext;
+use crate::error::JoshutoResult;
+
+use super::reload;
+
+pub fn switch_line_numbering(context: &mut AppContext, policy: u8) -> JoshutoResult<()> {
+    context
+        .config_mut()
+        .display_options_mut()
+        .set_line_nums(policy);
+    reload::reload_dirlist(context)
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -5,6 +5,7 @@ pub mod cursor_move;
 pub mod delete_files;
 pub mod file_ops;
 pub mod help;
+pub mod line_nums;
 pub mod new_directory;
 pub mod open_file;
 pub mod parent_cursor_move;

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -7,6 +7,7 @@ pub mod file_ops;
 pub mod help;
 pub mod line_nums;
 pub mod new_directory;
+pub mod numbered_command;
 pub mod open_file;
 pub mod parent_cursor_move;
 pub mod parent_directory;

--- a/src/commands/numbered_command.rs
+++ b/src/commands/numbered_command.rs
@@ -53,7 +53,7 @@ pub fn numbered_command(
                     }
                     key => match keymap.as_ref().get(&key) {
                         Some(CommandKeybind::SimpleKeybind(command)) => {
-                            return command.numbered_execute(num_prefix, context, backend, &keymap);
+                            return command.numbered_execute(num_prefix, context, backend, keymap);
                         }
                         _ => {
                             return Err(JoshutoError::new(

--- a/src/commands/numbered_command.rs
+++ b/src/commands/numbered_command.rs
@@ -1,0 +1,72 @@
+use termion::event::{Event, Key};
+
+use crate::commands::cursor_move;
+use crate::config::AppKeyMapping;
+use crate::context::AppContext;
+use crate::error::{JoshutoError, JoshutoErrorKind, JoshutoResult};
+use crate::event::AppEvent;
+use crate::key_command::{CommandKeybind, NumberedExecute};
+use crate::ui::views::TuiView;
+use crate::ui::TuiBackend;
+use crate::util::input;
+
+pub fn numbered_command(
+    first_char: char,
+    context: &mut AppContext,
+    backend: &mut TuiBackend,
+    keymap: &AppKeyMapping,
+) -> JoshutoResult<()> {
+    context.flush_event();
+    let mut prefix = String::from(first_char);
+
+    loop {
+        context.message_queue_mut().push_info(prefix.clone());
+        backend.render(TuiView::new(context));
+        context.message_queue_mut().pop_front();
+
+        let event = match context.poll_event() {
+            Ok(event) => event,
+            Err(_) => return Ok(()),
+        };
+
+        let num_prefix = match prefix.parse::<usize>() {
+            Ok(n) => n,
+            Err(_) => {
+                context.message_queue_mut().pop_front();
+                return Err(JoshutoError::new(
+                    JoshutoErrorKind::ParseError,
+                    "Number is too big".to_string(),
+                ));
+            }
+        };
+
+        match event {
+            AppEvent::Termion(event) => {
+                match event {
+                    Event::Key(Key::Esc) => return Ok(()),
+                    Event::Key(Key::Char('g')) => {
+                        cursor_move::cursor_move(num_prefix - 1, context);
+                        return Ok(());
+                    }
+                    Event::Key(Key::Char(c)) if c.is_numeric() => {
+                        prefix.push(c);
+                    }
+                    key => match keymap.as_ref().get(&key) {
+                        Some(CommandKeybind::SimpleKeybind(command)) => {
+                            return command.numbered_execute(num_prefix, context, backend, &keymap);
+                        }
+                        _ => {
+                            return Err(JoshutoError::new(
+                                JoshutoErrorKind::UnrecognizedCommand,
+                                "Command cannot be prefixed by a number or does not exist"
+                                    .to_string(),
+                            ));
+                        }
+                    },
+                }
+                context.flush_event();
+            }
+            event => input::process_noninteractive(event, context),
+        }
+    }
+}

--- a/src/config/general/display_crude.rs
+++ b/src/config/general/display_crude.rs
@@ -50,6 +50,9 @@ pub struct DisplayOptionCrude {
 
     #[serde(default, rename = "sort")]
     pub sort_options: SortOptionCrude,
+
+    #[serde(default)]
+    pub line_nums: String,
 }
 
 impl std::default::Default for DisplayOptionCrude {
@@ -65,6 +68,7 @@ impl std::default::Default for DisplayOptionCrude {
             show_preview: true,
             sort_options: SortOptionCrude::default(),
             tilde_in_titlebar: true,
+            line_nums: "0".to_string(),
         }
     }
 }
@@ -89,6 +93,12 @@ impl From<DisplayOptionCrude> for DisplayOption {
             Constraint::Ratio(0, total),
         ];
 
+        let _line_nums = match crude.line_nums.as_ref() {
+            "absolute" => 1,
+            "relative" => 2,
+            _ => 0,
+        };
+
         Self {
             _automatically_count_files: crude.automatically_count_files,
             _collapse_preview: crude.collapse_preview,
@@ -99,6 +109,7 @@ impl From<DisplayOptionCrude> for DisplayOption {
             _show_preview: crude.show_preview,
             _sort_options: crude.sort_options.into(),
             _tilde_in_titlebar: crude.tilde_in_titlebar,
+            _line_nums,
 
             column_ratio,
             default_layout,

--- a/src/config/general/display_crude.rs
+++ b/src/config/general/display_crude.rs
@@ -3,7 +3,7 @@ use std::convert::From;
 use serde_derive::Deserialize;
 use tui::layout::Constraint;
 
-use crate::config::option::DisplayOption;
+use crate::config::option::{DisplayOption, LineNumberStyle};
 
 use super::sort_crude::SortOptionCrude;
 
@@ -52,7 +52,7 @@ pub struct DisplayOptionCrude {
     pub sort_options: SortOptionCrude,
 
     #[serde(default)]
-    pub line_nums: String,
+    pub line_number_style: String,
 }
 
 impl std::default::Default for DisplayOptionCrude {
@@ -68,7 +68,7 @@ impl std::default::Default for DisplayOptionCrude {
             show_preview: true,
             sort_options: SortOptionCrude::default(),
             tilde_in_titlebar: true,
-            line_nums: "0".to_string(),
+            line_number_style: "none".to_string(),
         }
     }
 }
@@ -93,10 +93,10 @@ impl From<DisplayOptionCrude> for DisplayOption {
             Constraint::Ratio(0, total),
         ];
 
-        let _line_nums = match crude.line_nums.as_ref() {
-            "absolute" => 1,
-            "relative" => 2,
-            _ => 0,
+        let _line_nums = match crude.line_number_style.as_ref() {
+            "absolute" => LineNumberStyle::Absolute,
+            "relative" => LineNumberStyle::Relative,
+            _ => LineNumberStyle::None,
         };
 
         Self {

--- a/src/config/option/display_option.rs
+++ b/src/config/option/display_option.rs
@@ -19,10 +19,17 @@ pub struct DisplayOption {
     pub _show_preview: bool,
     pub _sort_options: SortOption,
     pub _tilde_in_titlebar: bool,
-    pub _line_nums: u8,
+    pub _line_nums: LineNumberStyle,
     pub column_ratio: (usize, usize, usize),
     pub default_layout: [Constraint; 3],
     pub no_preview_layout: [Constraint; 3],
+}
+
+#[derive(Clone, Copy, Debug)]
+pub enum LineNumberStyle {
+    None,
+    Relative,
+    Absolute,
 }
 
 impl DisplayOption {
@@ -70,12 +77,12 @@ impl DisplayOption {
         self._tilde_in_titlebar
     }
 
-    pub fn line_nums(&self) -> u8 {
+    pub fn line_nums(&self) -> LineNumberStyle {
         self._line_nums
     }
 
-    pub fn set_line_nums(&mut self, policy: u8) {
-        self._line_nums = policy;
+    pub fn set_line_nums(&mut self, style: LineNumberStyle) {
+        self._line_nums = style;
     }
 
     pub fn filter_func(&self) -> fn(&Result<fs::DirEntry, std::io::Error>) -> bool {
@@ -114,7 +121,7 @@ impl std::default::Default for DisplayOption {
             _show_preview: true,
             _sort_options: SortOption::default(),
             _tilde_in_titlebar: true,
-            _line_nums: 0,
+            _line_nums: LineNumberStyle::None,
             default_layout,
             no_preview_layout,
         }

--- a/src/config/option/display_option.rs
+++ b/src/config/option/display_option.rs
@@ -19,6 +19,7 @@ pub struct DisplayOption {
     pub _show_preview: bool,
     pub _sort_options: SortOption,
     pub _tilde_in_titlebar: bool,
+    pub _line_nums: u8,
     pub column_ratio: (usize, usize, usize),
     pub default_layout: [Constraint; 3],
     pub no_preview_layout: [Constraint; 3],
@@ -69,6 +70,14 @@ impl DisplayOption {
         self._tilde_in_titlebar
     }
 
+    pub fn line_nums(&self) -> u8 {
+        self._line_nums
+    }
+
+    pub fn set_line_nums(&mut self, policy: u8) {
+        self._line_nums = policy;
+    }
+
     pub fn filter_func(&self) -> fn(&Result<fs::DirEntry, std::io::Error>) -> bool {
         if self.show_hidden() {
             no_filter
@@ -105,6 +114,7 @@ impl std::default::Default for DisplayOption {
             _show_preview: true,
             _sort_options: SortOption::default(),
             _tilde_in_titlebar: true,
+            _line_nums: 0,
             default_layout,
             no_preview_layout,
         }

--- a/src/key_command/command.rs
+++ b/src/key_command/command.rs
@@ -1,6 +1,6 @@
 use std::path;
 
-use crate::config::option::{SelectOption, SortType};
+use crate::config::option::{LineNumberStyle, SelectOption, SortType};
 use crate::io::IoWorkerOptions;
 
 #[derive(Clone, Debug)]
@@ -62,7 +62,7 @@ pub enum Command {
 
     ToggleHiddenFiles,
 
-    SwitchLineNums(u8),
+    SwitchLineNums(LineNumberStyle),
 
     Sort(SortType),
     SortReverse,

--- a/src/key_command/command.rs
+++ b/src/key_command/command.rs
@@ -62,6 +62,8 @@ pub enum Command {
 
     ToggleHiddenFiles,
 
+    SwitchLineNums(u8),
+
     Sort(SortType),
     SortReverse,
 

--- a/src/key_command/constants.rs
+++ b/src/key_command/constants.rs
@@ -54,4 +54,5 @@ pub const CMD_SHOW_WORKERS: &str = "show_workers";
 pub const CMD_TAB_SWITCH: &str = "tab_switch";
 pub const CMD_TAB_SWITCH_INDEX: &str = "tab_switch_index";
 pub const CMD_TOGGLE_HIDDEN: &str = "toggle_hidden";
+pub const CMD_SWITCH_LINE_NUMBERS: &str = "line_nums";
 pub const CMD_TOUCH_FILE: &str = "touch";

--- a/src/key_command/impl_appcommand.rs
+++ b/src/key_command/impl_appcommand.rs
@@ -69,6 +69,7 @@ impl AppCommand for Command {
             Self::TabSwitch(_) => CMD_TAB_SWITCH,
             Self::TabSwitchIndex(_) => CMD_TAB_SWITCH_INDEX,
             Self::ToggleHiddenFiles => CMD_TOGGLE_HIDDEN,
+            Self::SwitchLineNums(_) => CMD_SWITCH_LINE_NUMBERS,
             Self::TouchFile(_) => CMD_TOUCH_FILE,
         }
     }

--- a/src/key_command/impl_appexecute.rs
+++ b/src/key_command/impl_appexecute.rs
@@ -85,6 +85,8 @@ impl AppExecute for Command {
 
             Self::ToggleHiddenFiles => show_hidden::toggle_hidden(context),
 
+            Self::SwitchLineNums(d) => line_nums::switch_line_numbering(context, *d),
+
             Self::Sort(t) => sort::set_sort(context, *t),
             Self::SortReverse => sort::toggle_reverse(context),
 

--- a/src/key_command/impl_comment.rs
+++ b/src/key_command/impl_comment.rs
@@ -80,6 +80,8 @@ impl CommandComment for Command {
 
             Self::ToggleHiddenFiles => "Toggle hidden files displaying",
 
+            Self::SwitchLineNums(_) => "Switch line numbering",
+
             Self::Sort(sort_type) => match sort_type {
                 SortType::Lexical => "Sort lexically",
                 SortType::Mtime => "Sort by modifiaction time",

--- a/src/key_command/impl_from_str.rs
+++ b/src/key_command/impl_from_str.rs
@@ -3,7 +3,7 @@ use std::path;
 use dirs_next::home_dir;
 use shellexpand::tilde_with_context;
 
-use crate::config::option::{SelectOption, SortType};
+use crate::config::option::{LineNumberStyle, SelectOption, SortType};
 use crate::error::{JoshutoError, JoshutoErrorKind};
 use crate::io::IoWorkerOptions;
 
@@ -293,18 +293,9 @@ impl std::str::FromStr for Command {
             Ok(Self::TouchFile(arg.to_string()))
         } else if command == CMD_SWITCH_LINE_NUMBERS {
             let policy = match arg {
-                "no" => 0,
-                "absolute" => 1,
-                "relative" => 2,
-                s => match s.parse::<u8>() {
-                    Ok(n) if (0..3).contains(&n) => n,
-                    _ => {
-                        return Err(JoshutoError::new(
-                            JoshutoErrorKind::InvalidParameters,
-                            format!("{}: {}", command, "Invalid argument. Must be 0/1/2"),
-                        ))
-                    }
-                },
+                "absolute" | "1" => LineNumberStyle::Absolute,
+                "relative" | "2" => LineNumberStyle::Relative,
+                _ => LineNumberStyle::None,
             };
             Ok(Self::SwitchLineNums(policy))
         } else {

--- a/src/key_command/impl_from_str.rs
+++ b/src/key_command/impl_from_str.rs
@@ -291,6 +291,22 @@ impl std::str::FromStr for Command {
             }
         } else if command == CMD_TOUCH_FILE {
             Ok(Self::TouchFile(arg.to_string()))
+        } else if command == CMD_SWITCH_LINE_NUMBERS {
+            let policy = match arg {
+                "no" => 0,
+                "absolute" => 1,
+                "relative" => 2,
+                s => match s.parse::<u8>() {
+                    Ok(n) if (0..3).contains(&n) => n,
+                    _ => {
+                        return Err(JoshutoError::new(
+                            JoshutoErrorKind::InvalidParameters,
+                            format!("{}: {}", command, "Invalid argument. Must be 0/1/2"),
+                        ))
+                    }
+                },
+            };
+            Ok(Self::SwitchLineNums(policy))
         } else {
             Err(JoshutoError::new(
                 JoshutoErrorKind::UnrecognizedCommand,

--- a/src/key_command/impl_numbered.rs
+++ b/src/key_command/impl_numbered.rs
@@ -9,8 +9,8 @@ use super::{Command, NumberedExecute};
 // In joshuto you can prefix simple commands with numbers by entering number,
 // and then pressing key which some command is bound to. This is used mainly
 // for easier navigation. You don't have to implement this for every command
-#[allow(unused)] // backend and keymap_t args are not used, but they probably will be
 impl NumberedExecute for Command {
+    #[allow(unused)] // backend and keymap_t args are not used, but they probably will be
     fn numbered_execute(
         &self,
         number_prefix: usize,

--- a/src/key_command/impl_numbered.rs
+++ b/src/key_command/impl_numbered.rs
@@ -1,0 +1,30 @@
+use crate::commands::*;
+use crate::config::AppKeyMapping;
+use crate::context::AppContext;
+use crate::error::{JoshutoError, JoshutoErrorKind, JoshutoResult};
+use crate::ui::TuiBackend;
+
+use super::{Command, NumberedExecute};
+
+// In joshuto you can prefix simple commands with numbers by entering number,
+// and then pressing key which some command is bound to. This is used mainly
+// for easier navigation. You don't have to implement this for every command
+#[allow(unused)] // backend and keymap_t args are not used, but they probably will be
+impl NumberedExecute for Command {
+    fn numbered_execute(
+        &self,
+        number_prefix: usize,
+        context: &mut AppContext,
+        backend: &mut TuiBackend,
+        keymap_t: &AppKeyMapping,
+    ) -> JoshutoResult<()> {
+        match self {
+            Self::CursorMoveUp(_) => cursor_move::up(context, number_prefix),
+            Self::CursorMoveDown(_) => cursor_move::down(context, number_prefix),
+            _ => Err(JoshutoError::new(
+                JoshutoErrorKind::UnrecognizedCommand,
+                "Command cannot be prefixed by a number".to_string(),
+            )),
+        }
+    }
+}

--- a/src/key_command/mod.rs
+++ b/src/key_command/mod.rs
@@ -8,6 +8,7 @@ mod impl_appexecute;
 mod impl_comment;
 mod impl_display;
 mod impl_from_str;
+mod impl_numbered;
 
 pub use self::command::*;
 pub use self::command_keybind::*;

--- a/src/key_command/traits.rs
+++ b/src/key_command/traits.rs
@@ -12,6 +12,16 @@ pub trait AppExecute {
     ) -> JoshutoResult<()>;
 }
 
+pub trait NumberedExecute {
+    fn numbered_execute(
+        &self,
+        number_prefix: usize,
+        context: &mut AppContext,
+        backend: &mut TuiBackend,
+        keymap_t: &AppKeyMapping,
+    ) -> JoshutoResult<()>;
+}
+
 pub trait AppCommand: AppExecute + std::fmt::Display + std::fmt::Debug {
     fn command(&self) -> &'static str;
 }

--- a/src/run.rs
+++ b/src/run.rs
@@ -1,5 +1,6 @@
-use termion::event::Event;
+use termion::event::{Event, Key};
 
+use crate::commands::numbered_command;
 use crate::config::AppKeyMapping;
 use crate::context::{AppContext, QuitType};
 use crate::event::AppEvent;
@@ -59,6 +60,13 @@ pub fn run(
                     Event::Unsupported(s) if s.as_slice() == [27, 79, 66] => {
                         let command = Command::CursorMoveDown(1);
                         if let Err(e) = command.execute(context, backend, &keymap_t) {
+                            context.message_queue_mut().push_error(e.to_string());
+                        }
+                    }
+                    Event::Key(Key::Char(c)) if c.is_numeric() && c != '0' => {
+                        if let Err(e) =
+                            numbered_command::numbered_command(c, context, backend, &keymap_t)
+                        {
                             context.message_queue_mut().push_error(e.to_string());
                         }
                     }

--- a/src/ui/views/tui_folder_view.rs
+++ b/src/ui/views/tui_folder_view.rs
@@ -127,7 +127,7 @@ impl<'a> Widget for TuiFolderView<'a> {
 
         // render current view
         if let Some(list) = curr_list.as_ref() {
-            TuiDirListDetailed::new(list).render(layout_rect[1], buf);
+            TuiDirListDetailed::new(list, display_options.line_nums()).render(layout_rect[1], buf);
             let rect = Rect {
                 x: 0,
                 y: area.height - 1,

--- a/src/ui/views/tui_folder_view.rs
+++ b/src/ui/views/tui_folder_view.rs
@@ -127,7 +127,7 @@ impl<'a> Widget for TuiFolderView<'a> {
 
         // render current view
         if let Some(list) = curr_list.as_ref() {
-            TuiDirListDetailed::new(list, display_options.line_nums()).render(layout_rect[1], buf);
+            TuiDirListDetailed::new(list, display_options).render(layout_rect[1], buf);
             let rect = Rect {
                 x: 0,
                 y: area.height - 1,


### PR DESCRIPTION
closes #41

Adds numbers for every entry in the main window. Supports both absolute numbering (As shown on the first screenshot in the linked issue), and relative numbering (As shown on the second screenshot, again, see the issue)

Work in progress:
  - Refactoring and improving the code
  - Adding documentation