### PR TITLE
Fix: DirList::need_update considers mtime change

### DIFF
--- a/src/commands/open_file.rs
+++ b/src/commands/open_file.rs
@@ -1,6 +1,7 @@
 use std::io;
 use std::path;
 
+use crate::commands::reload;
 use crate::config::AppMimetypeEntry;
 use crate::context::{AppContext, QuitType};
 use crate::error::{JoshutoError, JoshutoErrorKind, JoshutoResult};
@@ -34,6 +35,7 @@ pub fn open(context: &mut AppContext, backend: &mut TuiBackend) -> JoshutoResult
         if entry.file_path().is_dir() {
             let path = entry.file_path().to_path_buf();
             change_directory::cd(path.as_path(), context)?;
+            reload::soft_reload(context.tab_context_ref().index, context)?;
         } else {
             let paths = context
                 .tab_context_ref()

--- a/src/commands/tab_ops.rs
+++ b/src/commands/tab_ops.rs
@@ -40,6 +40,12 @@ fn _tab_switch(new_index: usize, context: &mut AppContext) -> std::io::Result<()
         history.remove(cwd.as_path());
     }
 
+    if let Some(cwd_parent) = cwd.parent() {
+        if history.create_or_soft_update(cwd_parent, &options).is_err() {
+            history.remove(cwd_parent);
+        }
+    }
+
     if let Some(file_path) = entry_path {
         if history
             .create_or_soft_update(file_path.as_path(), &options)

--- a/src/fs/dirlist.rs
+++ b/src/fs/dirlist.rs
@@ -96,7 +96,7 @@ impl JoshutoDirList {
     }
 
     pub fn need_update(&self) -> bool {
-        self._need_update
+        self._need_update || self.modified()
     }
 
     pub fn file_path(&self) -> &path::PathBuf {


### PR DESCRIPTION
1st commit: Fix: `JoshutoDirList::need_update` does not only consider explicit deprecation but also a changed mtime from the file system.

2nd commit: update also the left (parent dir) pane when switching tab

3rd commit: soft-reload also when opening a directory