### PR TITLE
add dynamic number of columns

### DIFF
--- a/config/joshuto.toml
+++ b/config/joshuto.toml
@@ -4,7 +4,7 @@ use_trash = true
 [display]
 automatically_count_files = false
 collapse_preview = true
-# ratios for parent view, current view and preview
+# ratios for parent view (optional), current view and preview
 column_ratio = [1, 4, 4]
 scroll_offset = 6
 show_borders = true

--- a/docs/configuration/joshuto.toml.md
+++ b/docs/configuration/joshuto.toml.md
@@ -21,7 +21,8 @@ max_preview_size = 2097152 # 2MB
 [display]
 # Collapse the preview window when there is no preview available
 collapse_preview = true
-# Ratios for parent view, current view and preview
+# Ratios for parent view, current view and preview. You can specify 0 for
+# parent view or omit it (So there are only 2 nums) and it won't be displayed
 column_ratio = [1, 3, 4]
 # Show borders around different views
 show_borders = true

--- a/src/config/general/display_crude.rs
+++ b/src/config/general/display_crude.rs
@@ -28,7 +28,7 @@ pub struct DisplayOptionCrude {
     pub collapse_preview: bool,
 
     #[serde(default)]
-    pub column_ratio: Option<[usize; 3]>,
+    pub column_ratio: Option<Vec<usize>>,
 
     #[serde(default = "default_scroll_offset")]
     pub scroll_offset: usize,
@@ -76,7 +76,8 @@ impl std::default::Default for DisplayOptionCrude {
 impl From<DisplayOptionCrude> for DisplayOption {
     fn from(crude: DisplayOptionCrude) -> Self {
         let column_ratio = match crude.column_ratio {
-            Some(s) => (s[0], s[1], s[2]),
+            Some(s) if s.len() == 3 => (s[0], s[1], s[2]),
+            Some(s) if s.len() == 2 => (0, s[0], s[1]),
             _ => default_column_ratio(),
         };
 

--- a/src/ui/views/tui_folder_view.rs
+++ b/src/ui/views/tui_folder_view.rs
@@ -32,7 +32,6 @@ impl<'a> Widget for TuiFolderView<'a> {
         let curr_tab = self.context.tab_context_ref().curr_tab_ref();
 
         let curr_list = curr_tab.curr_list_ref();
-        let parent_list = curr_tab.parent_list_ref();
         let child_list = curr_tab.child_list_ref();
 
         let curr_entry = curr_list.and_then(|c| c.curr_entry_ref());
@@ -87,7 +86,11 @@ impl<'a> Widget for TuiFolderView<'a> {
                     right,
                 };
 
-                intersections.render_left(buf);
+                // Won't render intersections if parent view is turned off
+                match constraints[0] {
+                    Constraint::Ratio(0, _) => (),
+                    _ => intersections.render_left(buf),
+                }
                 if default_layout {
                     intersections.render_right(buf);
                 }
@@ -121,8 +124,13 @@ impl<'a> Widget for TuiFolderView<'a> {
         };
 
         // render parent view
-        if let Some(list) = parent_list.as_ref() {
-            TuiDirList::new(list).render(layout_rect[0], buf);
+        match constraints[0] {
+            Constraint::Ratio(0, _) => (),
+            _ => {
+                if let Some(list) = curr_tab.parent_list_ref().as_ref() {
+                    TuiDirList::new(list).render(layout_rect[0], buf);
+                }
+            }
         }
 
         // render current view

--- a/src/ui/widgets/tui_dirlist.rs
+++ b/src/ui/widgets/tui_dirlist.rs
@@ -20,10 +20,7 @@ impl<'a> TuiDirList<'a> {
 
 impl<'a> Widget for TuiDirList<'a> {
     fn render(self, area: Rect, buf: &mut Buffer) {
-        if area.width < 1 || area.height < 1 {
-            return;
-        }
-        if area.width < 4 {
+        if area.width < 4 || area.height < 1 {
             return;
         }
         let x = area.left();


### PR DESCRIPTION
closes #104

Changes behavior of `column_ratio` property in **joshuto.toml**, now it can have length of 2 or 3. If it has length of 2 or first value is 0, parent view won't be displayed