### PR TITLE
Update view on filesystem changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,6 +161,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -241,6 +251,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "fsevent-sys"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c0e564d24da983c053beff1bb7178e237501206840a3e6bf4e267b9e8ae734a"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -294,6 +313,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
+dependencies = [
+ "bitflags",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "joshuto"
 version = "0.9.2"
 dependencies = [
@@ -306,6 +345,7 @@ dependencies = [
  "globset",
  "lazy_static",
  "libc",
+ "notify",
  "open",
  "phf",
  "rand",
@@ -325,6 +365,26 @@ dependencies = [
  "users",
  "whoami",
  "xdg",
+]
+
+[[package]]
+name = "kqueue"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "058a107a784f8be94c7d35c1300f4facced2e93d2fbe5b1452b44e905ddca4a9"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8367585489f01bc55dd27404dcf56b95e6da061a256a666ab23be9ba96a2e587"
+dependencies = [
+ "bitflags",
+ "libc",
 ]
 
 [[package]]
@@ -355,6 +415,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
+name = "mio"
+version = "0.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8067b404fe97c70829f082dec8bcf4f71225d7eaea1d8645349cb76fa06205cc"
+dependencies = [
+ "libc",
+ "log",
+ "miow",
+ "ntapi",
+ "winapi",
+]
+
+[[package]]
+name = "miow"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "nix"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -365,6 +447,33 @@ dependencies = [
  "cfg-if 0.1.10",
  "libc",
  "void",
+]
+
+[[package]]
+name = "notify"
+version = "5.0.0-pre.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "245d358380e2352c2d020e8ee62baac09b3420f1f6c012a31326cfced4ad487d"
+dependencies = [
+ "bitflags",
+ "crossbeam-channel",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "mio",
+ "walkdir",
+ "winapi",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -638,6 +747,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.130"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -850,6 +968,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
+name = "walkdir"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+dependencies = [
+ "same-file",
+ "winapi",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -882,6 +1011,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ phf = { version = "^0", features = ["macros"], optional = true }
 trash = { version = "^1", optional = true }
 unicode-segmentation = "^1"
 ansi-to-tui = "0.4.1"
+notify = "5.0.0-pre.13"
 
 [features]
 devicons = [ "phf" ]

--- a/src/event/app_event.rs
+++ b/src/event/app_event.rs
@@ -3,6 +3,8 @@ use std::path;
 use std::sync::mpsc;
 use std::thread;
 
+use notify;
+
 use signal_hook::consts::signal;
 use signal_hook::iterator::exfiltrator::SignalOnly;
 use signal_hook::iterator::SignalsInfo;
@@ -26,7 +28,7 @@ pub enum AppEvent {
     PreviewFile(path::PathBuf, io::Result<FilePreview>),
 
     Signal(i32),
-    //    Filesystem(notify::Result),
+    Filesystem(notify::Event),
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/src/run.rs
+++ b/src/run.rs
@@ -84,6 +84,7 @@ pub fn run(
             }
             event => input::process_noninteractive(event, context),
         }
+        context.update_watcher();
     }
 
     Ok(())

--- a/src/util/input.rs
+++ b/src/util/input.rs
@@ -1,11 +1,11 @@
+use notify;
+use signal_hook::consts::signal;
 use std::io;
 use std::path;
-
-use signal_hook::consts::signal;
 use termion::event::{Event, Key, MouseButton, MouseEvent};
 use tui::layout::{Constraint, Direction, Layout};
 
-use crate::commands::{cursor_move, parent_cursor_move};
+use crate::commands::{cursor_move, parent_cursor_move, reload};
 use crate::config::AppKeyMapping;
 use crate::context::AppContext;
 use crate::event::AppEvent;
@@ -63,8 +63,16 @@ pub fn process_noninteractive(event: AppEvent, context: &mut AppContext) {
             process_file_preview(context, path, file_preview)
         }
         AppEvent::Signal(signal::SIGWINCH) => {}
+        AppEvent::Filesystem(e) => process_filesystem_event(e, context),
         _ => {}
     }
+}
+
+fn process_filesystem_event(event: notify::Event, context: &mut AppContext) {
+    let event_str = format!("{:?}", event);
+    let tab = context.tab_context_mut().curr_tab_mut();
+    let curr_list_opt = tab.curr_list_mut();
+    let _ = reload::soft_reload(context.tab_context_ref().index, context);
 }
 
 pub fn process_new_worker(context: &mut AppContext) {

--- a/src/util/input.rs
+++ b/src/util/input.rs
@@ -68,10 +68,7 @@ pub fn process_noninteractive(event: AppEvent, context: &mut AppContext) {
     }
 }
 
-fn process_filesystem_event(event: notify::Event, context: &mut AppContext) {
-    let event_str = format!("{:?}", event);
-    let tab = context.tab_context_mut().curr_tab_mut();
-    let curr_list_opt = tab.curr_list_mut();
+fn process_filesystem_event(_event: notify::Event, context: &mut AppContext) {
     let _ = reload::soft_reload(context.tab_context_ref().index, context);
 }
 


### PR DESCRIPTION
AppContext owns an INotifyWatcher, which watches the visible directories
(max. three). The list of directories to watch is updated on every
event. If a filesystem change is announced, a "soft-update" of the
current view is issued.