### PR TITLE
Continuous scrolling 

### DIFF
--- a/docs/configuration/joshuto.toml.md
+++ b/docs/configuration/joshuto.toml.md
@@ -4,7 +4,6 @@ This file is for general configurations.
 All options available and their default values:
 ```toml
 # This is for configuring how many items to reach before 'scrolling' the view
-# CURRENTLY DOES NOT WORK
 scroll_offset = 6
 
 # If joshuto does not know how to open the file, it can resort to opening it via xdg settings

--- a/src/commands/change_directory.rs
+++ b/src/commands/change_directory.rs
@@ -13,11 +13,12 @@ pub fn cd(path: &path::Path, context: &mut AppContext) -> std::io::Result<()> {
 fn change_directory_helper(path: &path::Path, context: &mut AppContext) -> std::io::Result<()> {
     cd(path, context)?;
     let options = context.config_ref().display_options_ref().clone();
+    let ui_context = context.ui_context_ref().clone();
     context
         .tab_context_mut()
         .curr_tab_mut()
         .history_mut()
-        .populate_to_root(path, &options)?;
+        .populate_to_root(path, &ui_context, &options)?;
     Ok(())
 }
 

--- a/src/commands/cursor_move.rs
+++ b/src/commands/cursor_move.rs
@@ -42,13 +42,14 @@ pub fn cursor_move(context: &mut AppContext, new_index: usize) {
     lazy_load_directory_size(context);
     let mut new_index = new_index;
     let ui_context = context.ui_context_ref().clone();
+    let display_options = context.config_ref().display_options_ref().clone();
     if let Some(curr_list) = context.tab_context_mut().curr_tab_mut().curr_list_mut() {
         if !curr_list.is_empty() {
             let dir_len = curr_list.len();
             if new_index >= dir_len {
                 new_index = dir_len - 1;
             }
-            curr_list.set_index(Some(new_index), &ui_context);
+            curr_list.set_index(Some(new_index), &ui_context, &display_options);
         }
     }
 }

--- a/src/commands/cursor_move.rs
+++ b/src/commands/cursor_move.rs
@@ -41,20 +41,23 @@ pub fn lazy_load_directory_size(context: &mut AppContext) {
 pub fn cursor_move(context: &mut AppContext, new_index: usize) {
     lazy_load_directory_size(context);
     let mut new_index = new_index;
+    let ui_context = context.ui_context_ref().clone();
     if let Some(curr_list) = context.tab_context_mut().curr_tab_mut().curr_list_mut() {
         if !curr_list.is_empty() {
             let dir_len = curr_list.len();
             if new_index >= dir_len {
                 new_index = dir_len - 1;
             }
-            curr_list.index = Some(new_index);
+            curr_list.set_index(Some(new_index), &ui_context);
         }
     }
 }
 
 pub fn up(context: &mut AppContext, u: usize) -> JoshutoResult<()> {
     let movement = match context.tab_context_ref().curr_tab_ref().curr_list_ref() {
-        Some(curr_list) => curr_list.index.map(|idx| if idx > u { idx - u } else { 0 }),
+        Some(curr_list) => curr_list
+            .get_index()
+            .map(|idx| if idx > u { idx - u } else { 0 }),
         None => None,
     };
 
@@ -66,7 +69,7 @@ pub fn up(context: &mut AppContext, u: usize) -> JoshutoResult<()> {
 
 pub fn down(context: &mut AppContext, u: usize) -> JoshutoResult<()> {
     let movement = match context.tab_context_ref().curr_tab_ref().curr_list_ref() {
-        Some(curr_list) => curr_list.index.map(|idx| idx + u),
+        Some(curr_list) => curr_list.get_index().map(|idx| idx + u),
         None => None,
     };
     if let Some(s) = movement {
@@ -135,9 +138,11 @@ pub fn page_up(context: &mut AppContext, backend: &mut TuiBackend) -> JoshutoRes
     let page_size = get_page_size(context, backend).unwrap_or(10);
 
     let movement = match context.tab_context_ref().curr_tab_ref().curr_list_ref() {
-        Some(curr_list) => curr_list
-            .index
-            .map(|idx| if idx > page_size { idx - page_size } else { 0 }),
+        Some(curr_list) => {
+            curr_list
+                .get_index()
+                .map(|idx| if idx > page_size { idx - page_size } else { 0 })
+        }
         None => None,
     };
 
@@ -153,7 +158,7 @@ pub fn page_down(context: &mut AppContext, backend: &mut TuiBackend) -> JoshutoR
     let movement = match context.tab_context_ref().curr_tab_ref().curr_list_ref() {
         Some(curr_list) => {
             let dir_len = curr_list.len();
-            curr_list.index.map(|idx| {
+            curr_list.get_index().map(|idx| {
                 if idx + page_size > dir_len - 1 {
                     dir_len - 1
                 } else {

--- a/src/commands/parent_cursor_move.rs
+++ b/src/commands/parent_cursor_move.rs
@@ -8,17 +8,18 @@ pub fn parent_cursor_move(context: &mut AppContext, new_index: usize) -> Joshuto
     let mut new_index = new_index;
 
     {
+        let ui_context = context.ui_context_ref().clone();
         let curr_tab = context.tab_context_mut().curr_tab_mut();
         if let Some(curr_list) = curr_tab.parent_list_mut() {
-            if curr_list.index.is_some() {
+            if curr_list.get_index().is_some() {
                 let dir_len = curr_list.contents.len();
                 if new_index >= dir_len {
                     new_index = dir_len - 1;
                 }
                 let entry = &curr_list.contents[new_index];
                 if entry.file_path().is_dir() {
-                    curr_list.index = Some(new_index);
-                    path = Some(entry.file_path().to_path_buf())
+                    path = Some(entry.file_path().to_path_buf());
+                    curr_list.set_index(Some(new_index), &ui_context);
                 }
             }
         }
@@ -31,7 +32,9 @@ pub fn parent_cursor_move(context: &mut AppContext, new_index: usize) -> Joshuto
 
 pub fn parent_up(context: &mut AppContext, u: usize) -> JoshutoResult<()> {
     let movement = match context.tab_context_ref().curr_tab_ref().parent_list_ref() {
-        Some(list) => list.index.map(|idx| if idx > u { idx - u } else { 0 }),
+        Some(list) => list
+            .get_index()
+            .map(|idx| if idx > u { idx - u } else { 0 }),
         None => None,
     };
 
@@ -44,7 +47,7 @@ pub fn parent_up(context: &mut AppContext, u: usize) -> JoshutoResult<()> {
 
 pub fn parent_down(context: &mut AppContext, u: usize) -> JoshutoResult<()> {
     let movement = match context.tab_context_ref().curr_tab_ref().parent_list_ref() {
-        Some(list) => list.index.map(|idx| idx + u),
+        Some(list) => list.get_index().map(|idx| idx + u),
         None => None,
     };
     if let Some(s) = movement {

--- a/src/commands/parent_cursor_move.rs
+++ b/src/commands/parent_cursor_move.rs
@@ -9,6 +9,7 @@ pub fn parent_cursor_move(context: &mut AppContext, new_index: usize) -> Joshuto
 
     {
         let ui_context = context.ui_context_ref().clone();
+        let display_options = context.config_ref().display_options_ref().clone();
         let curr_tab = context.tab_context_mut().curr_tab_mut();
         if let Some(curr_list) = curr_tab.parent_list_mut() {
             if curr_list.get_index().is_some() {
@@ -19,7 +20,7 @@ pub fn parent_cursor_move(context: &mut AppContext, new_index: usize) -> Joshuto
                 let entry = &curr_list.contents[new_index];
                 if entry.file_path().is_dir() {
                     path = Some(entry.file_path().to_path_buf());
-                    curr_list.set_index(Some(new_index), &ui_context);
+                    curr_list.set_index(Some(new_index), &ui_context, &display_options);
                 }
             }
         }

--- a/src/commands/search_glob.rs
+++ b/src/commands/search_glob.rs
@@ -10,7 +10,7 @@ use super::cursor_move;
 pub fn search_glob_fwd(curr_tab: &JoshutoTab, glob: &GlobMatcher) -> Option<usize> {
     let curr_list = curr_tab.curr_list_ref()?;
 
-    let offset = curr_list.index? + 1;
+    let offset = curr_list.get_index()? + 1;
     let contents_len = curr_list.len();
     for i in 0..contents_len {
         let file_name = curr_list.contents[(offset + i) % contents_len].file_name();
@@ -23,7 +23,7 @@ pub fn search_glob_fwd(curr_tab: &JoshutoTab, glob: &GlobMatcher) -> Option<usiz
 pub fn search_glob_rev(curr_tab: &JoshutoTab, glob: &GlobMatcher) -> Option<usize> {
     let curr_list = curr_tab.curr_list_ref()?;
 
-    let offset = curr_list.index?;
+    let offset = curr_list.get_index()?;
     let contents_len = curr_list.len();
     for i in (0..contents_len).rev() {
         let file_name = curr_list.contents[(offset + i) % contents_len].file_name();

--- a/src/commands/search_string.rs
+++ b/src/commands/search_string.rs
@@ -8,7 +8,7 @@ use super::cursor_move;
 pub fn search_string_fwd(curr_tab: &JoshutoTab, pattern: &str) -> Option<usize> {
     let curr_list = curr_tab.curr_list_ref()?;
 
-    let offset = curr_list.index? + 1;
+    let offset = curr_list.get_index()? + 1;
     let contents_len = curr_list.contents.len();
     for i in 0..contents_len {
         let file_name_lower = curr_list.contents[(offset + i) % contents_len]
@@ -23,7 +23,7 @@ pub fn search_string_fwd(curr_tab: &JoshutoTab, pattern: &str) -> Option<usize> 
 pub fn search_string_rev(curr_tab: &JoshutoTab, pattern: &str) -> Option<usize> {
     let curr_list = curr_tab.curr_list_ref()?;
 
-    let offset = curr_list.index?;
+    let offset = curr_list.get_index()?;
     let contents_len = curr_list.contents.len();
     for i in (0..contents_len).rev() {
         let file_name_lower = curr_list.contents[(offset + i) % contents_len]

--- a/src/commands/subdir_fzf.rs
+++ b/src/commands/subdir_fzf.rs
@@ -80,8 +80,9 @@ pub fn fzf_change_dir(context: &mut AppContext, path: &Path) -> JoshutoResult<()
         };
 
         if let Some(index) = index {
+            let ui_context = context.ui_context_ref().clone();
             if let Some(curr_list) = context.tab_context_mut().curr_tab_mut().curr_list_mut() {
-                curr_list.index = Some(index);
+                curr_list.set_index(Some(index), &ui_context);
             }
         }
     }

--- a/src/commands/subdir_fzf.rs
+++ b/src/commands/subdir_fzf.rs
@@ -81,8 +81,9 @@ pub fn fzf_change_dir(context: &mut AppContext, path: &Path) -> JoshutoResult<()
 
         if let Some(index) = index {
             let ui_context = context.ui_context_ref().clone();
+            let display_options = context.config_ref().display_options_ref().clone();
             if let Some(curr_list) = context.tab_context_mut().curr_tab_mut().curr_list_mut() {
-                curr_list.set_index(Some(index), &ui_context);
+                curr_list.set_index(Some(index), &ui_context, &display_options);
             }
         }
     }

--- a/src/commands/tab_ops.rs
+++ b/src/commands/tab_ops.rs
@@ -96,7 +96,11 @@ pub fn new_tab_home_path(context: &AppContext) -> path::PathBuf {
 pub fn new_tab(context: &mut AppContext) -> JoshutoResult<()> {
     let new_tab_path = new_tab_home_path(context);
 
-    let tab = JoshutoTab::new(new_tab_path, context.config_ref().display_options_ref())?;
+    let tab = JoshutoTab::new(
+        new_tab_path,
+        context.ui_context_ref(),
+        context.config_ref().display_options_ref(),
+    )?;
     context.tab_context_mut().push_tab(tab);
     let new_index = context.tab_context_ref().len() - 1;
     context.tab_context_mut().index = new_index;

--- a/src/context/app_context.rs
+++ b/src/context/app_context.rs
@@ -1,5 +1,6 @@
 use std::collections::HashSet;
 use std::sync::mpsc;
+use tui::layout::Rect;
 
 use crate::config;
 use crate::context::{
@@ -18,6 +19,11 @@ pub enum QuitType {
     Force,
     ToCurrentDirectory,
     ChooseFiles,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct UiContext {
+    pub layout: Vec<Rect>,
 }
 
 pub struct AppContext {
@@ -42,6 +48,8 @@ pub struct AppContext {
     preview_context: PreviewContext,
     // context related to command line
     commandline_context: CommandLineContext,
+    // user interface context; data which is input to both, the UI rendering and the app state
+    ui_context: UiContext,
     // filesystem watcher to inform about changes in shown directories
     #[cfg(target_os = "linux")]
     watcher: notify::INotifyWatcher,
@@ -81,6 +89,7 @@ impl AppContext {
             message_queue: MessageQueue::new(),
             worker_context: WorkerContext::new(event_tx),
             preview_context: PreviewContext::new(),
+            ui_context: UiContext { layout: vec![] },
             commandline_context,
             config,
             watcher,
@@ -170,6 +179,13 @@ impl AppContext {
     }
     pub fn preview_context_mut(&mut self) -> &mut PreviewContext {
         &mut self.preview_context
+    }
+
+    pub fn ui_context_ref(&self) -> &UiContext {
+        &self.ui_context
+    }
+    pub fn ui_context_mut(&mut self) -> &mut UiContext {
+        &mut self.ui_context
     }
 
     pub fn worker_context_ref(&self) -> &WorkerContext {

--- a/src/fs/dirlist.rs
+++ b/src/fs/dirlist.rs
@@ -17,7 +17,6 @@ pub struct JoshutoDirList {
     /// The index in this dir list to start with when rendering the list
     viewport_index: usize,
     _need_update: bool,
-    scroll_offset: usize,
 }
 
 impl JoshutoDirList {
@@ -36,7 +35,6 @@ impl JoshutoDirList {
             index,
             viewport_index,
             _need_update: false,
-            scroll_offset: options.scroll_offset(),
         }
     }
 
@@ -58,7 +56,6 @@ impl JoshutoDirList {
             _need_update: false,
             index,
             viewport_index: if let Some(ix) = index { ix } else { 0 },
-            scroll_offset: options.scroll_offset(),
         })
     }
 
@@ -66,17 +63,17 @@ impl JoshutoDirList {
         self.index
     }
 
-    fn update_viewport(&mut self, ui_context: &UiContext) {
+    fn update_viewport(&mut self, ui_context: &UiContext, options: &DisplayOption) {
         if let Some(ix) = self.index {
             let height = ui_context.layout[0].height as usize;
 
             // get scroll buffer size, corrected in case of too small terminal
             let scroll_offset = if height < 4 {
                 0
-            } else if self.scroll_offset * 2 > height - 1 {
+            } else if options.scroll_offset() * 2 > height - 1 {
                 height / 2 - 1
             } else {
-                self.scroll_offset
+                options.scroll_offset()
             };
 
             // calculate viewport
@@ -93,13 +90,18 @@ impl JoshutoDirList {
         }
     }
 
-    pub fn set_index(&mut self, index: Option<usize>, ui_context: &UiContext) {
+    pub fn set_index(
+        &mut self,
+        index: Option<usize>,
+        ui_context: &UiContext,
+        options: &DisplayOption,
+    ) {
         if index == self.index {
             return;
         }
         self.index = index;
         if ui_context.layout.len() != 0 {
-            self.update_viewport(ui_context);
+            self.update_viewport(ui_context, options);
         }
     }
 

--- a/src/fs/dirlist.rs
+++ b/src/fs/dirlist.rs
@@ -26,7 +26,6 @@ impl JoshutoDirList {
         index: Option<usize>,
         viewport_index: usize,
         metadata: JoshutoMetadata,
-        options: &DisplayOption,
     ) -> Self {
         Self {
             path,

--- a/src/fs/dirlist.rs
+++ b/src/fs/dirlist.rs
@@ -25,6 +25,7 @@ impl JoshutoDirList {
         path: path::PathBuf,
         contents: Vec<JoshutoDirEntry>,
         index: Option<usize>,
+        viewport_index: usize,
         metadata: JoshutoMetadata,
         options: &DisplayOption,
     ) -> Self {
@@ -33,7 +34,7 @@ impl JoshutoDirList {
             contents,
             metadata,
             index,
-            viewport_index: 0,
+            viewport_index,
             _need_update: false,
             scroll_offset: options.scroll_offset(),
         }
@@ -56,7 +57,7 @@ impl JoshutoDirList {
             metadata,
             _need_update: false,
             index,
-            viewport_index: 0,
+            viewport_index: if let Some(ix) = index { ix } else { 0 },
             scroll_offset: options.scroll_offset(),
         })
     }

--- a/src/fs/dirlist.rs
+++ b/src/fs/dirlist.rs
@@ -1,7 +1,9 @@
+use std::cmp;
 use std::path;
 use std::slice::{Iter, IterMut};
 
 use crate::config::option::DisplayOption;
+use crate::context::UiContext;
 use crate::fs::{JoshutoDirEntry, JoshutoMetadata};
 use crate::history::read_directory;
 
@@ -10,9 +12,14 @@ pub struct JoshutoDirList {
     path: path::PathBuf,
     pub contents: Vec<JoshutoDirEntry>,
     pub metadata: JoshutoMetadata,
-    pub index: Option<usize>,
-    pub viewport_index: usize,
+    /// The cursor position in this dir list
+    index: Option<usize>,
+    /// The index in this dir list to start with when rendering the list
+    viewport_index: usize,
+    /// The height of the view-port when rendered last time, or 0 when not rendered yet
+    viewport_height: usize,
     _need_update: bool,
+    scroll_offset: usize,
 }
 
 impl JoshutoDirList {
@@ -21,6 +28,7 @@ impl JoshutoDirList {
         contents: Vec<JoshutoDirEntry>,
         index: Option<usize>,
         metadata: JoshutoMetadata,
+        options: &DisplayOption,
     ) -> Self {
         Self {
             path,
@@ -28,7 +36,9 @@ impl JoshutoDirList {
             metadata,
             index,
             viewport_index: 0,
+            viewport_height: 0,
             _need_update: false,
+            scroll_offset: options.scroll_offset(),
         }
     }
 
@@ -41,17 +51,6 @@ impl JoshutoDirList {
 
         let index = if contents.is_empty() { None } else { Some(0) };
 
-        let viewport_index = match index {
-            None => 0,
-            Some(index) => {
-                if index < options.scroll_offset() {
-                    0
-                } else {
-                    index - options.scroll_offset()
-                }
-            }
-        };
-
         let metadata = JoshutoMetadata::from(&path)?;
 
         Ok(Self {
@@ -60,8 +59,51 @@ impl JoshutoDirList {
             metadata,
             _need_update: false,
             index,
-            viewport_index,
+            viewport_index: 0,
+            viewport_height: 0,
+            scroll_offset: options.scroll_offset(),
         })
+    }
+
+    pub fn get_index(&self) -> Option<usize> {
+        self.index
+    }
+
+    fn update_viewport(&mut self, ui_context: &UiContext) {
+        if let Some(ix) = self.index {
+            let height = ui_context.layout[0].height as usize;
+
+            // get scroll buffer size, corrected in case of too small terminal
+            let scroll_offset = if height < 4 {
+                0
+            } else if self.scroll_offset * 2 > height - 1 {
+                height / 2 - 1
+            } else {
+                self.scroll_offset
+            };
+
+            // calculate viewport
+            let viewport_end = self.viewport_index + height;
+            if (viewport_end as i16 - ix as i16 - 1) < scroll_offset as i16 {
+                // cursor too low
+                self.viewport_index = (ix + scroll_offset - height + 1) as usize;
+            } else if (ix as i16 - self.viewport_index as i16) < scroll_offset as i16 {
+                // cursor too high
+                self.viewport_index = cmp::max(ix as i16 - scroll_offset as i16, 0) as usize;
+            }
+        } else {
+            self.viewport_index = 0;
+        }
+    }
+
+    pub fn set_index(&mut self, index: Option<usize>, ui_context: &UiContext) {
+        if index == self.index {
+            return;
+        }
+        self.index = index;
+        if ui_context.layout.len() != 0 {
+            self.update_viewport(ui_context);
+        }
     }
 
     pub fn iter(&self) -> Iter<JoshutoDirEntry> {
@@ -138,15 +180,9 @@ impl JoshutoDirList {
         self.get_curr_mut_(self.index?)
     }
 
-    /// For a given number of entries, visible in a UI, this method returns the index of the entry
-    /// with which the UI should start to list the entries.
-    ///
-    /// This method assures that the cursor is always in the viewport of the UI.
-    pub fn first_index_for_viewport(&self, viewport_height: usize) -> usize {
-        match self.index {
-            Some(index) => index / viewport_height as usize * viewport_height as usize,
-            None => 0,
-        }
+    /// Returns the index of the first entry to be printed in a UI dir list
+    pub fn first_index_for_viewport(&self) -> usize {
+        self.viewport_index
     }
 
     fn get_curr_mut_(&mut self, index: usize) -> Option<&mut JoshutoDirEntry> {

--- a/src/fs/dirlist.rs
+++ b/src/fs/dirlist.rs
@@ -16,8 +16,6 @@ pub struct JoshutoDirList {
     index: Option<usize>,
     /// The index in this dir list to start with when rendering the list
     viewport_index: usize,
-    /// The height of the view-port when rendered last time, or 0 when not rendered yet
-    viewport_height: usize,
     _need_update: bool,
     scroll_offset: usize,
 }
@@ -36,7 +34,6 @@ impl JoshutoDirList {
             metadata,
             index,
             viewport_index: 0,
-            viewport_height: 0,
             _need_update: false,
             scroll_offset: options.scroll_offset(),
         }
@@ -60,7 +57,6 @@ impl JoshutoDirList {
             _need_update: false,
             index,
             viewport_index: 0,
-            viewport_height: 0,
             scroll_offset: options.scroll_offset(),
         })
     }

--- a/src/history.rs
+++ b/src/history.rs
@@ -173,7 +173,6 @@ pub fn create_dirlist_with_history(
         index,
         viewport_index,
         metadata,
-        options,
     );
 
     Ok(dirlist)

--- a/src/history.rs
+++ b/src/history.rs
@@ -39,7 +39,7 @@ impl DirectoryHistory for JoshutoHistory {
                 let mut new_dirlist = create_dirlist_with_history(self, curr, options)?;
                 if let Some(ancestor) = prev.as_ref() {
                     if let Some(i) = get_index_of_value(&new_dirlist.contents, ancestor) {
-                        new_dirlist.set_index(Some(i), &ui_context);
+                        new_dirlist.set_index(Some(i), &ui_context, &options);
                     }
                 }
                 dirlists.push(new_dirlist);
@@ -48,7 +48,7 @@ impl DirectoryHistory for JoshutoHistory {
                     JoshutoDirList::from_path(curr.to_path_buf().clone(), options)?;
                 if let Some(ancestor) = prev.as_ref() {
                     if let Some(i) = get_index_of_value(&new_dirlist.contents, ancestor) {
-                        new_dirlist.set_index(Some(i), &ui_context);
+                        new_dirlist.set_index(Some(i), &ui_context, &options);
                     }
                 }
                 dirlists.push(new_dirlist);

--- a/src/history.rs
+++ b/src/history.rs
@@ -154,9 +154,27 @@ pub fn create_dirlist_with_history(
             None => Some(0),
         }
     };
+    let viewport_index: usize = if contents_len == 0 {
+        0
+    } else {
+        match history.get(path) {
+            Some(dirlist) => match dirlist.first_index_for_viewport() {
+                i if i >= contents_len => contents_len - 1,
+                i => i,
+            },
+            None => 0,
+        }
+    };
 
     let metadata = JoshutoMetadata::from(path)?;
-    let dirlist = JoshutoDirList::new(path.to_path_buf(), contents, index, metadata, options);
+    let dirlist = JoshutoDirList::new(
+        path.to_path_buf(),
+        contents,
+        index,
+        viewport_index,
+        metadata,
+        options,
+    );
 
     Ok(dirlist)
 }

--- a/src/preview/preview_default.rs
+++ b/src/preview/preview_default.rs
@@ -44,7 +44,7 @@ pub fn load_preview(context: &mut AppContext, backend: &mut TuiBackend) {
     let curr_tab = context.tab_context_ref().curr_tab_ref();
     match curr_tab.curr_list_ref() {
         Some(curr_list) => {
-            if let Some(index) = curr_list.index {
+            if let Some(index) = curr_list.get_index() {
                 let entry = &curr_list.contents[index];
                 load_list.push((entry.file_path().to_path_buf(), entry.metadata.clone()));
             }

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -1,6 +1,7 @@
 use std::path;
 
 use crate::config::option::DisplayOption;
+use crate::context::UiContext;
 use crate::fs::JoshutoDirList;
 use crate::history::{DirectoryHistory, JoshutoHistory};
 
@@ -17,9 +18,13 @@ pub struct JoshutoTab {
 }
 
 impl JoshutoTab {
-    pub fn new(cwd: path::PathBuf, options: &DisplayOption) -> std::io::Result<Self> {
+    pub fn new(
+        cwd: path::PathBuf,
+        ui_context: &UiContext,
+        options: &DisplayOption,
+    ) -> std::io::Result<Self> {
         let mut history = JoshutoHistory::new();
-        history.populate_to_root(cwd.as_path(), options)?;
+        history.populate_to_root(cwd.as_path(), ui_context, options)?;
 
         Ok(Self { _cwd: cwd, history })
     }
@@ -51,7 +56,7 @@ impl JoshutoTab {
 
     pub fn child_list_ref(&self) -> Option<&JoshutoDirList> {
         let curr_list = self.curr_list_ref()?;
-        let index = curr_list.index?;
+        let index = curr_list.get_index()?;
         let path = curr_list.contents[index].file_path();
         self.history.get(path)
     }
@@ -69,7 +74,7 @@ impl JoshutoTab {
     pub fn child_list_mut(&mut self) -> Option<&mut JoshutoDirList> {
         let child_path = {
             let curr_list = self.curr_list_ref()?;
-            let index = curr_list.index?;
+            let index = curr_list.get_index()?;
             curr_list.contents[index].file_path().to_path_buf()
         };
 

--- a/src/ui/widgets/tui_dirlist.rs
+++ b/src/ui/widgets/tui_dirlist.rs
@@ -32,8 +32,8 @@ impl<'a> Widget for TuiDirList<'a> {
             return;
         }
 
-        let curr_index = self.dirlist.index.unwrap();
-        let skip_dist = self.dirlist.first_index_for_viewport(area.height as usize);
+        let curr_index = self.dirlist.get_index().unwrap();
+        let skip_dist = self.dirlist.first_index_for_viewport();
 
         let drawing_width = area.width as usize;
 
@@ -43,26 +43,21 @@ impl<'a> Widget for TuiDirList<'a> {
             .enumerate()
             .take(area.height as usize)
             .for_each(|(i, entry)| {
-                let style = style::entry_style(entry);
+                let ix = skip_dist + i;
+
+                let style = if ix == curr_index {
+                    style::entry_style(entry).add_modifier(Modifier::REVERSED)
+                } else {
+                    style::entry_style(entry)
+                };
+
+                if ix == curr_index {
+                    let space_fill = " ".repeat(drawing_width);
+                    buf.set_string(x, y + i as u16, space_fill.as_str(), style);
+                }
+
                 print_entry(buf, entry, style, (x + 1, y + i as u16), drawing_width - 1);
             });
-
-        // draw selected entry in a different style
-        let screen_index = curr_index % area.height as usize;
-
-        let entry = self.dirlist.curr_entry_ref().unwrap();
-        let style = style::entry_style(entry).add_modifier(Modifier::REVERSED);
-
-        let space_fill = " ".repeat(drawing_width);
-        buf.set_string(x, y + screen_index as u16, space_fill.as_str(), style);
-
-        print_entry(
-            buf,
-            entry,
-            style,
-            (x + 1, y + screen_index as u16),
-            drawing_width - 1,
-        );
     }
 }
 

--- a/src/ui/widgets/tui_footer.rs
+++ b/src/ui/widgets/tui_footer.rs
@@ -22,7 +22,7 @@ impl<'a> TuiFooter<'a> {
 impl<'a> Widget for TuiFooter<'a> {
     fn render(self, area: Rect, buf: &mut Buffer) {
         use std::os::unix::fs::PermissionsExt;
-        match self.dirlist.index {
+        match self.dirlist.get_index() {
             Some(i) if i < self.dirlist.len() => {
                 let entry = &self.dirlist.contents[i];
 

--- a/src/util/input.rs
+++ b/src/util/input.rs
@@ -237,8 +237,7 @@ pub fn process_mouse(
                     )
                 };
                 if let Some(dirlist) = dirlist {
-                    let skip_dist =
-                        dirlist.first_index_for_viewport(layout_rect[1].height as usize);
+                    let skip_dist = dirlist.first_index_for_viewport();
                     let new_index = skip_dist + (y - layout_rect[1].y - 1) as usize;
                     if is_parent {
                         if let Err(e) = parent_cursor_move::parent_cursor_move(context, new_index) {


### PR DESCRIPTION
The scrolling behavior is changed from “paging” to a continuous
scrolling. Joshuto keeps a buffer from the cursor to each end of the
list, which is configured by `[display] scroll_offset`. If the terminal
height is too small to keep the distance, the buffer is set to a value
that assures that the cursor is at least as close to the end the user is
scrolling towards as to the other end of the visible list.

If the window is resized and the cursor jumps out of scope, the viewport
is adjusted when changing the index next time.

Possible improvements:
* Issue a viewport update on terminal geometry change
* When scrolling down to the bottom, don't allow an empty section
  beneath the last entry