### PR TITLE
Fix: invoke correct hook script

### DIFF
--- a/src/run.rs
+++ b/src/run.rs
@@ -166,7 +166,7 @@ fn process_preview_on_change(
             }
         }
         None => {
-            if let Some(hook_script) = preview_shown_hook_script {
+            if let Some(hook_script) = preview_removed_hook_script {
                 let hook_script = hook_script.to_path_buf();
                 let _ = thread::spawn(|| {
                     let _ = process::Command::new(hook_script).status();


### PR DESCRIPTION
When the preview disappears, the "shown" hook script was spawned instead
of the "removed" hook script.

This mistake was not obvious with the preview-image recipe from the docs
which works also with the shown-script on remove.