### PR TITLE
Update external preview on geometry change

### DIFF
--- a/src/context/app_context.rs
+++ b/src/context/app_context.rs
@@ -155,6 +155,7 @@ impl AppContext {
             Some(new) => {
                 let should_preview = if let Some(old) = &self.preview_area {
                     new.file_preview_path != old.file_preview_path
+                        || new.preview_area != old.preview_area
                 } else {
                     true
                 };


### PR DESCRIPTION
When the size of the preview area changes, the "preview shown hook" is
called to give a chance to update the size and/or position of the
preview image.