### PR TITLE
fix doc of shown-hook for icat

### DIFF
--- a/docs/image_previews.md
+++ b/docs/image_previews.md
@@ -250,6 +250,8 @@ case $(file -b --mime-type "${file}") in
 	image/*)
 		image "${file}"
 		;;
+    *)
+	    kitty +kitten icat --transfer-mode=file --clear 2>/dev/null
 esac
 ```
 


### PR DESCRIPTION
When changing from an image file to another file type, the last image
was not cleared with the given description.