### PR TITLE
Move half page

### DIFF
--- a/config/keymap.toml
+++ b/config/keymap.toml
@@ -27,6 +27,8 @@ mapcommand = [
 	{ keys = [ "home" ],		command = "cursor_move_home" },
 	{ keys = [ "page_up" ],		command = "cursor_move_page_up" },
 	{ keys = [ "page_down" ],	command = "cursor_move_page_down" },
+	{ keys = [ "ctrl+u" ],  	command = "cursor_move_page_up 0.5" },
+	{ keys = [ "ctrl+d" ], 		command = "cursor_move_page_down 0.5" },
 
 	# vim-like keybindings
 	{ keys = [ "j" ],		command = "cursor_move_down" },

--- a/src/commands/cursor_move.rs
+++ b/src/commands/cursor_move.rs
@@ -54,7 +54,7 @@ pub fn cursor_move(context: &mut AppContext, new_index: usize) {
     }
 }
 
-pub fn up(context: &mut AppContext, u: usize) -> JoshutoResult<()> {
+pub fn up(context: &mut AppContext, u: usize) -> JoshutoResult {
     let movement = match context.tab_context_ref().curr_tab_ref().curr_list_ref() {
         Some(curr_list) => curr_list
             .get_index()
@@ -68,7 +68,7 @@ pub fn up(context: &mut AppContext, u: usize) -> JoshutoResult<()> {
     Ok(())
 }
 
-pub fn down(context: &mut AppContext, u: usize) -> JoshutoResult<()> {
+pub fn down(context: &mut AppContext, u: usize) -> JoshutoResult {
     let movement = match context.tab_context_ref().curr_tab_ref().curr_list_ref() {
         Some(curr_list) => curr_list.get_index().map(|idx| idx + u),
         None => None,
@@ -79,7 +79,7 @@ pub fn down(context: &mut AppContext, u: usize) -> JoshutoResult<()> {
     Ok(())
 }
 
-pub fn home(context: &mut AppContext) -> JoshutoResult<()> {
+pub fn home(context: &mut AppContext) -> JoshutoResult {
     let movement: Option<usize> = match context.tab_context_ref().curr_tab_ref().curr_list_ref() {
         Some(curr_list) => {
             let len = curr_list.len();
@@ -98,7 +98,7 @@ pub fn home(context: &mut AppContext) -> JoshutoResult<()> {
     Ok(())
 }
 
-pub fn end(context: &mut AppContext) -> JoshutoResult<()> {
+pub fn end(context: &mut AppContext) -> JoshutoResult {
     let movement: Option<usize> = match context.tab_context_ref().curr_tab_ref().curr_list_ref() {
         Some(curr_list) => {
             let len = curr_list.len();
@@ -135,8 +135,13 @@ fn get_page_size(context: &AppContext, backend: &TuiBackend) -> Option<usize> {
     }
 }
 
-pub fn page_up(context: &mut AppContext, backend: &mut TuiBackend) -> JoshutoResult<()> {
-    let page_size = get_page_size(context, backend).unwrap_or(10);
+pub fn page_up(
+    context: &mut AppContext,
+    backend: &mut TuiBackend,
+    proportion: f64,
+) -> JoshutoResult {
+    let page_size = get_page_size(context, backend).unwrap_or(10) as f64 * proportion;
+    let page_size = page_size as usize;
 
     let movement = match context.tab_context_ref().curr_tab_ref().curr_list_ref() {
         Some(curr_list) => {
@@ -153,8 +158,13 @@ pub fn page_up(context: &mut AppContext, backend: &mut TuiBackend) -> JoshutoRes
     Ok(())
 }
 
-pub fn page_down(context: &mut AppContext, backend: &mut TuiBackend) -> JoshutoResult<()> {
-    let page_size = get_page_size(context, backend).unwrap_or(10);
+pub fn page_down(
+    context: &mut AppContext,
+    backend: &mut TuiBackend,
+    proportion: f64,
+) -> JoshutoResult {
+    let page_size = get_page_size(context, backend).unwrap_or(10) as f64 * proportion;
+    let page_size = page_size as usize;
 
     let movement = match context.tab_context_ref().curr_tab_ref().curr_list_ref() {
         Some(curr_list) => {

--- a/src/commands/help.rs
+++ b/src/commands/help.rs
@@ -54,8 +54,8 @@ pub fn help_loop(
                                     Command::CursorMoveDown(_) => move_offset(&mut offset, 1),
                                     Command::CursorMoveHome => offset = 0,
                                     Command::CursorMoveEnd => offset = 255,
-                                    Command::CursorMovePageUp => move_offset(&mut offset, -10),
-                                    Command::CursorMovePageDown => move_offset(&mut offset, 10),
+                                    Command::CursorMovePageUp(_) => move_offset(&mut offset, -10),
+                                    Command::CursorMovePageDown(_) => move_offset(&mut offset, 10),
                                     Command::CloseTab | Command::Help => break,
                                     _ => (),
                                 }

--- a/src/key_command/command.rs
+++ b/src/key_command/command.rs
@@ -25,8 +25,8 @@ pub enum Command {
     CursorMoveDown(usize),
     CursorMoveHome,
     CursorMoveEnd,
-    CursorMovePageUp,
-    CursorMovePageDown,
+    CursorMovePageUp(f64),
+    CursorMovePageDown(f64),
 
     ParentCursorMoveUp(usize),
     ParentCursorMoveDown(usize),

--- a/src/key_command/impl_appcommand.rs
+++ b/src/key_command/impl_appcommand.rs
@@ -32,8 +32,8 @@ impl AppCommand for Command {
             Self::CursorMoveDown(_) => CMD_CURSOR_MOVE_DOWN,
             Self::CursorMoveHome => CMD_CURSOR_MOVE_HOME,
             Self::CursorMoveEnd => CMD_CURSOR_MOVE_END,
-            Self::CursorMovePageUp => CMD_CURSOR_MOVE_PAGEUP,
-            Self::CursorMovePageDown => CMD_CURSOR_MOVE_PAGEDOWN,
+            Self::CursorMovePageUp(_) => CMD_CURSOR_MOVE_PAGEUP,
+            Self::CursorMovePageDown(_) => CMD_CURSOR_MOVE_PAGEDOWN,
 
             Self::ParentCursorMoveUp(_) => CMD_PARENT_CURSOR_MOVE_UP,
             Self::ParentCursorMoveDown(_) => CMD_PARENT_CURSOR_MOVE_DOWN,

--- a/src/key_command/impl_appexecute.rs
+++ b/src/key_command/impl_appexecute.rs
@@ -42,8 +42,8 @@ impl AppExecute for Command {
             Self::CursorMoveDown(u) => cursor_move::down(context, *u),
             Self::CursorMoveHome => cursor_move::home(context),
             Self::CursorMoveEnd => cursor_move::end(context),
-            Self::CursorMovePageUp => cursor_move::page_up(context, backend),
-            Self::CursorMovePageDown => cursor_move::page_down(context, backend),
+            Self::CursorMovePageUp(p) => cursor_move::page_up(context, backend, *p),
+            Self::CursorMovePageDown(p) => cursor_move::page_down(context, backend, *p),
 
             Self::ParentCursorMoveUp(u) => parent_cursor_move::parent_up(context, *u),
             Self::ParentCursorMoveDown(u) => parent_cursor_move::parent_down(context, *u),

--- a/src/key_command/impl_comment.rs
+++ b/src/key_command/impl_comment.rs
@@ -44,8 +44,8 @@ impl CommandComment for Command {
             Self::CursorMoveDown(_) => "Move cursor down",
             Self::CursorMoveHome => "Move cursor to the very top",
             Self::CursorMoveEnd => "Move cursor to the ver bottom",
-            Self::CursorMovePageUp => "Move cursor one page up",
-            Self::CursorMovePageDown => "Move cursor one page down",
+            Self::CursorMovePageUp(_) => "Move cursor one page up",
+            Self::CursorMovePageDown(_) => "Move cursor one page down",
 
             Self::ParentCursorMoveUp(_) => "Cursor up in parent list",
             Self::ParentCursorMoveDown(_) => "Cursor down in parent list",

--- a/src/key_command/impl_from_str.rs
+++ b/src/key_command/impl_from_str.rs
@@ -48,12 +48,6 @@ impl std::str::FromStr for Command {
 
         simple_command_conversion_case!(command, CMD_CURSOR_MOVE_HOME, Self::CursorMoveHome);
         simple_command_conversion_case!(command, CMD_CURSOR_MOVE_END, Self::CursorMoveEnd);
-        simple_command_conversion_case!(command, CMD_CURSOR_MOVE_PAGEUP, Self::CursorMovePageUp);
-        simple_command_conversion_case!(
-            command,
-            CMD_CURSOR_MOVE_PAGEDOWN,
-            Self::CursorMovePageDown
-        );
 
         simple_command_conversion_case!(command, CMD_CUT_FILES, Self::CutFiles);
         simple_command_conversion_case!(command, CMD_DELETE_FILES, Self::DeleteFiles);
@@ -109,6 +103,12 @@ impl std::str::FromStr for Command {
                     )),
                 },
             }
+        } else if command == CMD_CURSOR_MOVE_PAGEUP {
+            let p = arg.trim().parse::<f64>().unwrap_or(1.);
+            Ok(Self::CursorMovePageUp(p))
+        } else if command == CMD_CURSOR_MOVE_PAGEDOWN {
+            let p = arg.trim().parse::<f64>().unwrap_or(1.);
+            Ok(Self::CursorMovePageDown(p))
         } else if command == CMD_CURSOR_MOVE_UP {
             match arg {
                 "" => Ok(Self::CursorMoveUp(1)),


### PR DESCRIPTION
`ctrl+d` and `ctrl+u` are used in vim to move half page down and up accordingly. Add support for the same thing.