### PR TITLE
Add docker to build the binary and copy it to a clean busybox image

### DIFF
--- a/.Dockerignore
+++ b/.Dockerignore
@@ -1,0 +1,9 @@
+config
+docs
+target
+Cargo.lock
+Docker*
+LICENSE
+README.md
+screenshot.png
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM rust:latest AS builder
+
+COPY . /usr/src/joshuto
+
+WORKDIR /usr/src/joshuto
+
+RUN rustup target add x86_64-unknown-linux-musl \
+  && cargo build --target x86_64-unknown-linux-musl --release
+
+FROM busybox:latest
+
+COPY target/x86_64-unknown-linux-musl/release/joshuto /bin/joshuto
+
+WORKDIR /root
+


### PR DESCRIPTION
Not sure if it's useful but the Dockerfile compiles joshuto in a rust container and copy the binary into a busybox image. It results in a slim image with joshuto. 

  

Instructions: 

  

``` bash 

docker build -t joshuto:0.9.2 . 

``` 

``` bash 

docker run --rm -it -u $(id -u):$(id -g) -v $(pwd):/root joshuto:0.9.2 

``` 

And inside the container: 

  

``` bash 

joshuto 

``` 