### PR TITLE
use cli-clipboard for path copy

### DIFF
--- a/src/commands/file_ops.rs
+++ b/src/commands/file_ops.rs
@@ -121,6 +121,10 @@ fn copy_string_to_buffer(string: String) -> JoshutoResult {
             format!("printf '%s' '{}' | {} -ib 2> /dev/null", string, "xsel"),
         ),
         (
+            "pbcopy",
+            format!("printf '%s' '{}' | {} 2> /dev/null", string, "pbcopy"),
+        ),
+        (
             "xclip",
             format!(
                 "printf '%s' '{}' | {} -selection clipboard 2> /dev/null",


### PR DESCRIPTION
Hi, 

I have xclip installed on my MacOS and it hangs during path copy. Use the clipboard library for better cross platform support.