### PR TITLE
docs: fix joshuto function

### DIFF
--- a/docs/configuration/keymap.toml.md
+++ b/docs/configuration/keymap.toml.md
@@ -64,6 +64,7 @@ f12
 ```bash
 function joshuto() {
 	ID="$$"
+	mkdir -p /tmp/$USER
 	OUTPUT_FILE="/tmp/$USER/joshuto-cwd-$ID"
 	env joshuto --output-file "$OUTPUT_FILE" $@
 	exit_code=$?


### PR DESCRIPTION
Some system doesn't come with `/tmp/$USER` by default.