### PR TITLE
Use rustfmt defaults

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,1 @@
+# Using defaults as defined at https://github.com/rust-lang/rustfmt/blob/master/Configurations.md


### PR DESCRIPTION
Without this file, rustfmt's configuration might be coming from a developer's global configuration for rustfmt. To ensure consistency, we define an empty rustfmt configuration. This is explained upstream:

> Rustfmt is designed to be very configurable. You can create a TOML file called `rustfmt.toml` or `.rustfmt.toml`, place it in the project or any other parent directory and it will apply the options in that file. If none of these directories contain such a file, both your home directory and a directory called `rustfmt` in your [global config directory](https://docs.rs/dirs/1.0.4/dirs/fn.config_dir.html) (e.g. `.config/rustfmt/`) are checked as well.