### PR TITLE
Bump `ansi-to-tui` to `0.6` and remove `tui_old`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,11 +19,11 @@ checksum = "77e9c9abb82613923ec78d7a461595d52491ba7240f3c64c0bbe0e6d98e0fce0"
 
 [[package]]
 name = "ansi-to-tui"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "432bad6a85e6443b2ba2296fb43c6d843594f2f0daa55a8b86202dd3c1dc0a99"
+checksum = "33ef15b7b32ef426166ba4f153a0ade6fb3b81b20ff3d2cdbc89c369f5a2e620"
 dependencies = [
- "tui 0.17.0",
+ "tui",
 ]
 
 [[package]]
@@ -388,8 +388,7 @@ dependencies = [
  "termion",
  "toml",
  "trash",
- "tui 0.17.0",
- "tui 0.18.0",
+ "tui",
  "unicode-segmentation",
  "unicode-width",
  "users",
@@ -1033,19 +1032,6 @@ dependencies = [
  "scopeguard",
  "url",
  "windows",
-]
-
-[[package]]
-name = "tui"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23ed0a32c88b039b73f1b6c5acbd0554bfa5b6be94467375fd947c4de3a02271"
-dependencies = [
- "bitflags",
- "cassowary",
- "termion",
- "unicode-segmentation",
- "unicode-width",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,8 +31,7 @@ structopt = "^0"
 termion = "^1"
 toml = "^0"
 trash = { version = "^2", optional = true }
-tui_old = { package = "tui", version = "0.17", default-features = false, features = ["termion"] }
-tui = { version = "0.18", default-features = false, features = ["termion"] }
+tui = { version = "^0", default-features = false, features = ["termion"] }
 unicode-segmentation = "^1"
 unicode-width = "^0"
 users = "^0"

--- a/src/ui/widgets/tui_file_preview.rs
+++ b/src/ui/widgets/tui_file_preview.rs
@@ -1,45 +1,9 @@
 use tui::buffer::Buffer;
 use tui::layout::Rect;
-use tui::style::{Color, Style};
-use tui::text::{Span, Spans};
+use tui::text::Span;
 use tui::widgets::Widget;
 
 use crate::preview::preview_file::FilePreview;
-
-fn color_to_color(color: tui_old::style::Color) -> Color {
-    match color {
-        tui_old::style::Color::Reset => Color::Reset,
-        tui_old::style::Color::Black => Color::Black,
-        tui_old::style::Color::Red => Color::Red,
-        tui_old::style::Color::Green => Color::Green,
-        tui_old::style::Color::Yellow => Color::Yellow,
-        tui_old::style::Color::Blue => Color::Blue,
-        tui_old::style::Color::Magenta => Color::Magenta,
-        tui_old::style::Color::Cyan => Color::Cyan,
-        tui_old::style::Color::Gray => Color::Gray,
-        tui_old::style::Color::DarkGray => Color::DarkGray,
-        tui_old::style::Color::LightRed => Color::LightRed,
-        tui_old::style::Color::LightGreen => Color::LightGreen,
-        tui_old::style::Color::LightYellow => Color::LightYellow,
-        tui_old::style::Color::LightBlue => Color::LightBlue,
-        tui_old::style::Color::LightMagenta => Color::LightMagenta,
-        tui_old::style::Color::LightCyan => Color::LightCyan,
-        tui_old::style::Color::White => Color::White,
-        tui_old::style::Color::Rgb(r, g, b) => Color::Rgb(r, g, b),
-        tui_old::style::Color::Indexed(i) => Color::Indexed(i),
-    }
-}
-
-fn style_to_style(style: tui_old::style::Style) -> Style {
-    let mut new_style = Style::default();
-    if let Some(fg) = style.fg {
-        new_style = new_style.fg(color_to_color(fg));
-    }
-    if let Some(bg) = style.bg {
-        new_style = new_style.fg(color_to_color(bg));
-    }
-    new_style
-}
 
 pub struct TuiFilePreview<'a> {
     preview: &'a FilePreview,
@@ -77,19 +41,6 @@ impl<'a> TuiFilePreview<'a> {
                     .skip(self.preview.index)
                     .zip(area.y..area.y + area.height)
                 {
-                    // required to convert between different tui-rs versions.
-                    // remove once ansi-to-tui depends on latest tui-rs
-                    let span_vec: Vec<Span> = line
-                        .0
-                        .iter()
-                        .map(|s| Span {
-                            content: s.content.clone(),
-                            style: style_to_style(s.style),
-                        })
-                        .collect();
-                    let spans = Spans(span_vec);
-                    let line = &spans;
-
                     buf.set_spans(area.x, y, line, area.width);
                 }
             }


### PR DESCRIPTION
`ansi-to-tui` 0.6 uses the latest `tui`