### PR TITLE
File type filter for key maps

### DIFF
--- a/src/commands/show_help.rs
+++ b/src/commands/show_help.rs
@@ -48,18 +48,24 @@ pub fn help_loop(
                         Event::Key(Key::Char('3')) => sort_by = 2,
                         Event::Key(Key::Char('/')) => search_query.push('/'),
                         event => {
-                            if let Some(CommandKeybind::SimpleKeybind(command)) =
+                            if let Some(CommandKeybind::SimpleKeybind(filetypes)) =
                                 keymap_t.help_view.get(&event)
                             {
-                                match command {
-                                    Command::CursorMoveUp(_) => move_offset(&mut offset, -1),
-                                    Command::CursorMoveDown(_) => move_offset(&mut offset, 1),
-                                    Command::CursorMoveHome => offset = 0,
-                                    Command::CursorMoveEnd => offset = 255,
-                                    Command::CursorMovePageUp(_) => move_offset(&mut offset, -10),
-                                    Command::CursorMovePageDown(_) => move_offset(&mut offset, 10),
-                                    Command::CloseTab | Command::Help => break,
-                                    _ => (),
+                                if let Some(command) = filetypes.get(&None) {
+                                    match command {
+                                        Command::CursorMoveUp(_) => move_offset(&mut offset, -1),
+                                        Command::CursorMoveDown(_) => move_offset(&mut offset, 1),
+                                        Command::CursorMoveHome => offset = 0,
+                                        Command::CursorMoveEnd => offset = 255,
+                                        Command::CursorMovePageUp(_) => {
+                                            move_offset(&mut offset, -10)
+                                        }
+                                        Command::CursorMovePageDown(_) => {
+                                            move_offset(&mut offset, 10)
+                                        }
+                                        Command::CloseTab | Command::Help => break,
+                                        _ => (),
+                                    }
                                 }
                             }
                         }

--- a/src/commands/show_tasks.rs
+++ b/src/commands/show_tasks.rs
@@ -28,8 +28,8 @@ pub fn show_tasks(
                                 .message_queue_mut()
                                 .push_info(format!("Unmapped input: {}", key.to_string()));
                         }
-                        Some(CommandKeybind::SimpleKeybind(command)) => {
-                            if let Command::ShowTasks = command {
+                        Some(CommandKeybind::SimpleKeybind(filetypes)) => {
+                            if matches!(filetypes.get(&None), Some(Command::ShowTasks)) {
                                 break;
                             }
                         }

--- a/src/fs/metadata.rs
+++ b/src/fs/metadata.rs
@@ -2,6 +2,7 @@ use serde_derive::Deserialize;
 use std::{fs, io, path, time};
 
 #[derive(Clone, Copy, Hash, Eq, PartialEq, Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum FileType {
     Directory,
     File,

--- a/src/fs/metadata.rs
+++ b/src/fs/metadata.rs
@@ -1,6 +1,7 @@
+use serde_derive::Deserialize;
 use std::{fs, io, path, time};
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Hash, Eq, PartialEq, Debug, Deserialize)]
 pub enum FileType {
     Directory,
     File,

--- a/src/key_command/command_keybind.rs
+++ b/src/key_command/command_keybind.rs
@@ -8,12 +8,3 @@ pub enum CommandKeybind {
     SimpleKeybind(HashMap<Option<FileType>, Command>),
     CompositeKeybind(KeyMapping),
 }
-
-// impl std::fmt::Display for CommandKeybind {
-//     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-//         match self {
-//             CommandKeybind::SimpleKeybind(s) => write!(f, "{}", s),
-//             CommandKeybind::CompositeKeybind(_) => write!(f, "..."),
-//         }
-//     }
-// }

--- a/src/key_command/command_keybind.rs
+++ b/src/key_command/command_keybind.rs
@@ -1,17 +1,19 @@
 use crate::config::KeyMapping;
+use crate::fs::FileType;
 use crate::key_command::Command;
+use std::collections::HashMap;
 
 #[derive(Debug)]
 pub enum CommandKeybind {
-    SimpleKeybind(Command),
+    SimpleKeybind(HashMap<Option<FileType>, Command>),
     CompositeKeybind(KeyMapping),
 }
 
-impl std::fmt::Display for CommandKeybind {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        match self {
-            CommandKeybind::SimpleKeybind(s) => write!(f, "{}", s),
-            CommandKeybind::CompositeKeybind(_) => write!(f, "..."),
-        }
-    }
-}
+// impl std::fmt::Display for CommandKeybind {
+//     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+//         match self {
+//             CommandKeybind::SimpleKeybind(s) => write!(f, "{}", s),
+//             CommandKeybind::CompositeKeybind(_) => write!(f, "..."),
+//         }
+//     }
+// }

--- a/src/run.rs
+++ b/src/run.rs
@@ -88,9 +88,27 @@ pub fn run(
                                 .message_queue_mut()
                                 .push_info(format!("Unmapped input: {}", key.to_string()));
                         }
-                        Some(CommandKeybind::SimpleKeybind(command)) => {
-                            if let Err(e) = command.execute(context, backend, &keymap_t) {
-                                context.message_queue_mut().push_error(e.to_string());
+                        Some(CommandKeybind::SimpleKeybind(filetypes)) => {
+                            let command = context
+                                .tab_context_ref()
+                                .curr_tab_ref()
+                                .curr_list_ref()
+                                .and_then(|s| s.curr_entry_ref())
+                                .map(|entry| *entry.metadata.file_type())
+                                .and_then(|filetype| filetypes.get(&Some(filetype)))
+                                .or_else(|| filetypes.get(&None));
+
+                            match command {
+                                Some(command) => {
+                                    if let Err(e) = command.execute(context, backend, &keymap_t) {
+                                        context.message_queue_mut().push_error(e.to_string());
+                                    }
+                                }
+                                None => {
+                                    context
+                                        .message_queue_mut()
+                                        .push_info(format!("Unmapped input: {}", key.to_string()));
+                                }
                             }
                         }
                         Some(CommandKeybind::CompositeKeybind(m)) => {

--- a/src/ui/views/tui_command_menu.rs
+++ b/src/ui/views/tui_command_menu.rs
@@ -6,6 +6,8 @@ use tui::widgets::{Clear, Widget};
 
 use crate::config::KeyMapping;
 use crate::context::AppContext;
+use crate::fs::FileType;
+use crate::key_command::CommandKeybind;
 use crate::ui::views::TuiView;
 use crate::ui::widgets::TuiMenu;
 use crate::util::to_string::ToString;
@@ -32,7 +34,22 @@ impl<'a> Widget for TuiCommandMenu<'a> {
         let mut display_vec: Vec<String> = self
             .keymap
             .iter()
-            .map(|(k, v)| format!("  {}        {}", k.to_string(), v))
+            .flat_map(|(k, v)| match v {
+                CommandKeybind::SimpleKeybind(s) => s
+                    .iter()
+                    .map(|(filetype, command)| {
+                        let filetype = match filetype {
+                            None => "",
+                            Some(FileType::Directory) => " [Directory]",
+                            Some(FileType::File) => " [File]",
+                        };
+                        format!("  {}        {}{}", k.to_string(), command, filetype)
+                    })
+                    .collect(),
+                CommandKeybind::CompositeKeybind(..) => {
+                    vec![format!("  {}        ...", k.to_string())]
+                }
+            })
             .collect();
         display_vec.sort();
         let display_str: Vec<&str> = display_vec.iter().map(|v| v.as_str()).collect();


### PR DESCRIPTION
With the recent change that implemented `quit --output-selected-files`, the `open` command no longer causes an exit the way `--choosefiles` did. I liked using it that way, where "opening" a file when using Joshuto as a file picker was doing the `quit --output-selected-files` action. 

To get that back, I have added a new field `filetype` to the keymap file, so I can write something like this:

```toml
[[default_view.keymap]]
command = "open"
keys = ["arrow_right"]
filetype = "directory"
[[default_view.keymap]]
command = "quit --output-selected-files"
keys = ["arrow_right"]
filetype = "file"
```

Now each key can do a different thing based on whether the entry is a directory or a regular file. This might even make it possible to remove that special case in `open` for directories, and change `arrow_right` on directory to do a `cd` instead, allowing `open` on a directory to do something even more special, if so desired (open in OS file explorer/open as project in VS code, etc)