### PR TITLE
Sort options individual per tab

### DIFF
--- a/src/commands/change_directory.rs
+++ b/src/commands/change_directory.rs
@@ -24,11 +24,16 @@ pub fn change_directory(context: &mut AppContext, path: &path::Path) -> JoshutoR
     cd(new_cwd.as_path(), context)?;
     let options = context.config_ref().display_options_ref().clone();
     let ui_context = context.ui_context_ref().clone();
+    let tab_options = context
+        .tab_context_ref()
+        .curr_tab_ref()
+        .option_ref()
+        .clone();
     context
         .tab_context_mut()
         .curr_tab_mut()
         .history_mut()
-        .populate_to_root(new_cwd.as_path(), &ui_context, &options)?;
+        .populate_to_root(new_cwd.as_path(), &ui_context, &options, &tab_options)?;
     Ok(())
 }
 

--- a/src/commands/delete_files.rs
+++ b/src/commands/delete_files.rs
@@ -77,10 +77,13 @@ fn _delete_selected_files(
 ) -> std::io::Result<()> {
     delete_files(context, backend, false)?;
 
+    let curr_tab = context.tab_context_ref().curr_tab_ref();
     let options = context.config_ref().display_options_ref().clone();
-    let curr_path = context.tab_context_ref().curr_tab_ref().cwd().to_path_buf();
+    let curr_path = curr_tab.cwd().to_path_buf();
+    let tab_option = curr_tab.option_ref().clone();
     for tab in context.tab_context_mut().iter_mut() {
-        tab.history_mut().reload(&curr_path, &options)?;
+        tab.history_mut()
+            .reload(&curr_path, &options, &tab_option)?;
     }
     Ok(())
 }
@@ -96,10 +99,13 @@ fn _delete_selected_files_background(
 ) -> std::io::Result<()> {
     delete_files(context, backend, true)?;
 
+    let curr_tab = context.tab_context_ref().curr_tab_ref();
     let options = context.config_ref().display_options_ref().clone();
-    let curr_path = context.tab_context_ref().curr_tab_ref().cwd().to_path_buf();
+    let curr_path = curr_tab.cwd().to_path_buf();
+    let tab_option = curr_tab.option_ref().clone();
     for tab in context.tab_context_mut().iter_mut() {
-        tab.history_mut().reload(&curr_path, &options)?;
+        tab.history_mut()
+            .reload(&curr_path, &options, &tab_option)?;
     }
     Ok(())
 }

--- a/src/commands/flat.rs
+++ b/src/commands/flat.rs
@@ -48,6 +48,11 @@ pub fn flatten(depth: usize, context: &mut AppContext) -> JoshutoResult {
     let path = context.tab_context_ref().curr_tab_ref().cwd().to_path_buf();
 
     let options = context.config_ref().display_options_ref().clone();
+    let tab_options = context
+        .tab_context_ref()
+        .curr_tab_ref()
+        .option_ref()
+        .clone();
 
     let mut index: Option<usize> = context
         .tab_context_ref()
@@ -69,7 +74,8 @@ pub fn flatten(depth: usize, context: &mut AppContext) -> JoshutoResult {
         index = None;
     }
 
-    let sort_options = options.sort_options_ref();
+    let sort_options = tab_options.sort_options_ref();
+
     contents.sort_by(|f1, f2| sort_options.compare(f1, f2));
 
     let metadata = JoshutoMetadata::from(path.as_path())?;

--- a/src/commands/new_directory.rs
+++ b/src/commands/new_directory.rs
@@ -7,9 +7,15 @@ use crate::history::DirectoryHistory;
 pub fn new_directory(context: &mut AppContext, p: &path::Path) -> JoshutoResult {
     std::fs::create_dir_all(p)?;
     let options = context.config_ref().display_options_ref().clone();
+    let tab_options = context
+        .tab_context_ref()
+        .curr_tab_ref()
+        .option_ref()
+        .clone();
     let curr_path = context.tab_context_ref().curr_tab_ref().cwd().to_path_buf();
     for tab in context.tab_context_mut().iter_mut() {
-        tab.history_mut().reload(&curr_path, &options)?;
+        tab.history_mut()
+            .reload(&curr_path, &options, &tab_options)?;
     }
     Ok(())
 }

--- a/src/commands/reload.rs
+++ b/src/commands/reload.rs
@@ -25,13 +25,19 @@ pub fn soft_reload(index: usize, context: &mut AppContext) -> std::io::Result<()
 
     if !paths.is_empty() {
         let options = context.config_ref().display_options_ref().clone();
+        let tab_options = context
+            .tab_context_ref()
+            .curr_tab_ref()
+            .option_ref()
+            .clone();
         if let Some(history) = context
             .tab_context_mut()
             .tab_mut(index)
             .map(|t| t.history_mut())
         {
             for path in paths {
-                let new_dirlist = create_dirlist_with_history(history, path.as_path(), &options)?;
+                let new_dirlist =
+                    create_dirlist_with_history(history, path.as_path(), &options, &tab_options)?;
                 history.insert(path, new_dirlist);
             }
         }
@@ -55,13 +61,19 @@ pub fn reload(context: &mut AppContext, index: usize) -> std::io::Result<()> {
 
     if !paths.is_empty() {
         let options = context.config_ref().display_options_ref().clone();
+        let tab_options = context
+            .tab_context_ref()
+            .curr_tab_ref()
+            .option_ref()
+            .clone();
         if let Some(history) = context
             .tab_context_mut()
             .tab_mut(index)
             .map(|t| t.history_mut())
         {
             for path in paths {
-                let new_dirlist = create_dirlist_with_history(history, path.as_path(), &options)?;
+                let new_dirlist =
+                    create_dirlist_with_history(history, path.as_path(), &options, &tab_options)?;
                 history.insert(path, new_dirlist);
             }
         }

--- a/src/commands/rename_file.rs
+++ b/src/commands/rename_file.rs
@@ -20,17 +20,22 @@ pub fn _rename_file(
     }
     std::fs::rename(&src, &dest)?;
 
-    let path = context
-        .tab_context_ref()
-        .curr_tab_ref()
+    let curr_tab = context.tab_context_ref().curr_tab_ref();
+
+    let path = curr_tab
         .curr_list_ref()
         .map(|lst| lst.file_path().to_path_buf());
 
     if let Some(path) = path {
         let options = context.config_ref().display_options_ref().clone();
-
+        let tab_options = context
+            .tab_context_ref()
+            .curr_tab_ref()
+            .option_ref()
+            .clone();
         let history = context.tab_context_mut().curr_tab_mut().history_mut();
-        let new_dirlist = create_dirlist_with_history(history, path.as_path(), &options)?;
+        let new_dirlist =
+            create_dirlist_with_history(history, path.as_path(), &options, &tab_options)?;
         history.insert(path, new_dirlist);
     }
     Ok(())

--- a/src/commands/sort.rs
+++ b/src/commands/sort.rs
@@ -6,23 +6,20 @@ use crate::history::DirectoryHistory;
 use super::reload;
 
 pub fn set_sort(context: &mut AppContext, method: SortType) -> JoshutoResult {
-    context
-        .config_mut()
+    let curr_tab = context.tab_context_mut().curr_tab_mut();
+    curr_tab
+        .option_mut()
         .sort_options_mut()
         .set_sort_method(method);
-    for tab in context.tab_context_mut().iter_mut() {
-        tab.history_mut().depreciate_all_entries();
-    }
+    curr_tab.history_mut().depreciate_all_entries();
     refresh(context)
 }
 
 pub fn toggle_reverse(context: &mut AppContext) -> JoshutoResult {
-    let reversed = !context.config_ref().sort_options_ref().reverse;
-    context.config_mut().sort_options_mut().reverse = reversed;
-
-    for tab in context.tab_context_mut().iter_mut() {
-        tab.history_mut().depreciate_all_entries();
-    }
+    let curr_tab = context.tab_context_mut().curr_tab_mut();
+    let reversed = !curr_tab.option_mut().sort_options_ref().reverse;
+    curr_tab.option_mut().sort_options_mut().reverse = reversed;
+    curr_tab.history_mut().depreciate_all_entries();
     refresh(context)
 }
 

--- a/src/commands/tab_ops.rs
+++ b/src/commands/tab_ops.rs
@@ -32,23 +32,31 @@ fn _tab_switch(new_index: usize, context: &mut AppContext) -> std::io::Result<()
     };
 
     let options = context.config_ref().display_options_ref().clone();
+    let tab_options = context
+        .tab_context_ref()
+        .curr_tab_ref()
+        .option_ref()
+        .clone();
     let history = context.tab_context_mut().curr_tab_mut().history_mut();
     if history
-        .create_or_soft_update(cwd.as_path(), &options)
+        .create_or_soft_update(cwd.as_path(), &options, &tab_options)
         .is_err()
     {
         history.remove(cwd.as_path());
     }
 
     if let Some(cwd_parent) = cwd.parent() {
-        if history.create_or_soft_update(cwd_parent, &options).is_err() {
+        if history
+            .create_or_soft_update(cwd_parent, &options, &tab_options)
+            .is_err()
+        {
             history.remove(cwd_parent);
         }
     }
 
     if let Some(file_path) = entry_path {
         if history
-            .create_or_soft_update(file_path.as_path(), &options)
+            .create_or_soft_update(file_path.as_path(), &options, &tab_options)
             .is_err()
         {
             history.remove(file_path.as_path());

--- a/src/commands/touch_file.rs
+++ b/src/commands/touch_file.rs
@@ -19,6 +19,7 @@ fn _create_file(file: &path::Path) -> std::io::Result<()> {
 }
 
 pub fn touch_file(context: &mut AppContext, arg: &str) -> JoshutoResult {
+    let curr_tab = context.tab_context_ref().curr_tab_ref();
     match arg {
         "" => {
             if let Some(selected_file_path) = context
@@ -41,17 +42,20 @@ pub fn touch_file(context: &mut AppContext, arg: &str) -> JoshutoResult {
         }
     }
 
-    let path = context
-        .tab_context_ref()
-        .curr_tab_ref()
+    let path = curr_tab
         .curr_list_ref()
         .map(|lst| lst.file_path().to_path_buf());
 
     if let Some(path) = path {
         let options = context.config_ref().display_options_ref().clone();
-
+        let tab_options = context
+            .tab_context_ref()
+            .curr_tab_ref()
+            .option_ref()
+            .clone();
         let history = context.tab_context_mut().curr_tab_mut().history_mut();
-        let new_dirlist = create_dirlist_with_history(history, path.as_path(), &options)?;
+        let new_dirlist =
+            create_dirlist_with_history(history, path.as_path(), &options, &tab_options)?;
         history.insert(path, new_dirlist);
     }
     Ok(())

--- a/src/config/general/app.rs
+++ b/src/config/general/app.rs
@@ -1,7 +1,7 @@
 use super::app_raw::AppConfigRaw;
 use super::DEFAULT_CONFIG_FILE_PATH;
 
-use crate::config::option::{DisplayOption, PreviewOption, SortOption, TabOption};
+use crate::config::option::{DisplayOption, PreviewOption, TabOption};
 use crate::error::JoshutoResult;
 
 #[derive(Debug, Clone)]
@@ -33,13 +33,6 @@ impl AppConfig {
     }
     pub fn _preview_options_mut(&mut self) -> &mut PreviewOption {
         &mut self._preview_options
-    }
-
-    pub fn sort_options_ref(&self) -> &SortOption {
-        self.display_options_ref().sort_options_ref()
-    }
-    pub fn sort_options_mut(&mut self) -> &mut SortOption {
-        self.display_options_mut().sort_options_mut()
     }
 
     pub fn tab_options_ref(&self) -> &TabOption {

--- a/src/config/general/display_raw.rs
+++ b/src/config/general/display_raw.rs
@@ -3,7 +3,7 @@ use std::convert::From;
 use serde_derive::Deserialize;
 use tui::layout::Constraint;
 
-use crate::config::option::{DisplayMode, DisplayOption, LineNumberStyle};
+use crate::config::option::{DisplayMode, DisplayOption, LineNumberStyle, TabDisplayOption};
 
 use super::sort_raw::SortOptionRaw;
 
@@ -117,13 +117,15 @@ impl From<DisplayOptionRaw> for DisplayOption {
             _show_borders: raw.show_borders,
             _show_hidden: raw.show_hidden,
             _show_icons: raw.show_icons,
-            _sort_options: raw.sort_options.into(),
             _tilde_in_titlebar: raw.tilde_in_titlebar,
             _line_nums,
 
             column_ratio,
             default_layout,
             no_preview_layout,
+            default_tab_display_option: TabDisplayOption {
+                _sort_options: raw.sort_options.into(),
+            },
         }
     }
 }

--- a/src/config/option/display_option.rs
+++ b/src/config/option/display_option.rs
@@ -14,6 +14,7 @@ pub const fn default_column_ratio() -> (usize, usize, usize) {
     (1, 3, 4)
 }
 
+/// Display options globally valid for Joshuto (for all tabs)
 #[derive(Clone, Debug)]
 pub struct DisplayOption {
     pub _mode: DisplayMode,
@@ -23,12 +24,18 @@ pub struct DisplayOption {
     pub _show_borders: bool,
     pub _show_hidden: bool,
     pub _show_icons: bool,
-    pub _sort_options: SortOption,
     pub _tilde_in_titlebar: bool,
     pub _line_nums: LineNumberStyle,
     pub column_ratio: (usize, usize, usize),
     pub default_layout: [Constraint; 3],
     pub no_preview_layout: [Constraint; 3],
+    pub default_tab_display_option: TabDisplayOption,
+}
+
+/// Display options valid per JoshutoTab
+#[derive(Clone, Debug)]
+pub struct TabDisplayOption {
+    pub _sort_options: SortOption,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -36,6 +43,16 @@ pub enum LineNumberStyle {
     None,
     Relative,
     Absolute,
+}
+
+impl TabDisplayOption {
+    pub fn sort_options_ref(&self) -> &SortOption {
+        &self._sort_options
+    }
+
+    pub fn sort_options_mut(&mut self) -> &mut SortOption {
+        &mut self._sort_options
+    }
 }
 
 impl DisplayOption {
@@ -69,14 +86,6 @@ impl DisplayOption {
 
     pub fn set_show_hidden(&mut self, show_hidden: bool) {
         self._show_hidden = show_hidden;
-    }
-
-    pub fn sort_options_ref(&self) -> &SortOption {
-        &self._sort_options
-    }
-
-    pub fn sort_options_mut(&mut self) -> &mut SortOption {
-        &mut self._sort_options
     }
 
     pub fn tilde_in_titlebar(&self) -> bool {
@@ -125,11 +134,13 @@ impl std::default::Default for DisplayOption {
             _show_borders: true,
             _show_hidden: false,
             _show_icons: false,
-            _sort_options: SortOption::default(),
             _tilde_in_titlebar: true,
             _line_nums: LineNumberStyle::None,
             default_layout,
             no_preview_layout,
+            default_tab_display_option: TabDisplayOption {
+                _sort_options: SortOption::default(),
+            },
         }
     }
 }

--- a/src/event/process_event.rs
+++ b/src/event/process_event.rs
@@ -92,9 +92,18 @@ pub fn process_finished_worker(
     let worker_context = context.worker_context_mut();
     let observer = worker_context.remove_worker().unwrap();
     let options = context.config_ref().display_options_ref().clone();
+    let tab_options = context
+        .tab_context_ref()
+        .curr_tab_ref()
+        .option_ref()
+        .clone();
     for tab in context.tab_context_mut().iter_mut() {
-        let _ = tab.history_mut().reload(observer.dest_path(), &options);
-        let _ = tab.history_mut().reload(observer.src_path(), &options);
+        let _ = tab
+            .history_mut()
+            .reload(observer.dest_path(), &options, &tab_options);
+        let _ = tab
+            .history_mut()
+            .reload(observer.src_path(), &options, &tab_options);
     }
 
     /* delete

--- a/src/fs/dirlist.rs
+++ b/src/fs/dirlist.rs
@@ -1,7 +1,7 @@
 use std::slice::{Iter, IterMut};
 use std::{io, path};
 
-use crate::config::option::DisplayOption;
+use crate::config::option::{DisplayOption, TabDisplayOption};
 use crate::context::UiContext;
 use crate::fs::{JoshutoDirEntry, JoshutoMetadata};
 use crate::history::read_directory;
@@ -36,12 +36,14 @@ impl JoshutoDirList {
         }
     }
 
-    pub fn from_path(path: path::PathBuf, options: &DisplayOption) -> io::Result<Self> {
+    pub fn from_path(
+        path: path::PathBuf,
+        options: &DisplayOption,
+        tab_options: &TabDisplayOption,
+    ) -> io::Result<Self> {
         let filter_func = options.filter_func();
-        let sort_options = options.sort_options_ref();
-
         let mut contents = read_directory(path.as_path(), filter_func, options)?;
-        contents.sort_by(|f1, f2| sort_options.compare(f1, f2));
+        contents.sort_by(|f1, f2| tab_options.sort_options_ref().compare(f1, f2));
 
         let index = if contents.is_empty() { None } else { Some(0) };
         let metadata = JoshutoMetadata::from(&path)?;

--- a/src/preview/preview_dir.rs
+++ b/src/preview/preview_dir.rs
@@ -11,9 +11,14 @@ impl Background {
     pub fn load_preview(context: &mut AppContext, p: path::PathBuf) -> thread::JoinHandle<()> {
         let event_tx = context.events.event_tx.clone();
         let options = context.config_ref().display_options_ref().clone();
+        let tab_options = context
+            .tab_context_ref()
+            .curr_tab_ref()
+            .option_ref()
+            .clone();
 
         thread::spawn(move || {
-            if let Ok(dirlist) = JoshutoDirList::from_path(p, &options) {
+            if let Ok(dirlist) = JoshutoDirList::from_path(p, &options, &tab_options) {
                 let _ = event_tx.send(AppEvent::PreviewDir(Ok(Box::new(dirlist))));
             }
         })

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -1,6 +1,6 @@
 use std::path;
 
-use crate::config::option::DisplayOption;
+use crate::config::option::{DisplayOption, TabDisplayOption};
 use crate::context::UiContext;
 use crate::fs::JoshutoDirList;
 use crate::history::{DirectoryHistory, JoshutoHistory};
@@ -17,6 +17,7 @@ pub struct JoshutoTab {
     _cwd: path::PathBuf,
     // history is just a HashMap, so we have this property to store last workdir
     _previous_dir: Option<path::PathBuf>,
+    options: TabDisplayOption,
 }
 
 impl JoshutoTab {
@@ -26,13 +27,25 @@ impl JoshutoTab {
         options: &DisplayOption,
     ) -> std::io::Result<Self> {
         let mut history = JoshutoHistory::new();
-        history.populate_to_root(cwd.as_path(), ui_context, options)?;
+        let tab_options = options.default_tab_display_option.clone();
 
-        Ok(Self {
+        history.populate_to_root(cwd.as_path(), ui_context, options, &tab_options)?;
+        let new_tab = Self {
             history,
             _cwd: cwd,
             _previous_dir: None,
-        })
+            options: tab_options,
+        };
+
+        Ok(new_tab)
+    }
+
+    pub fn option_ref(&self) -> &TabDisplayOption {
+        &self.options
+    }
+
+    pub fn option_mut(&mut self) -> &mut TabDisplayOption {
+        &mut self.options
     }
 
     pub fn cwd(&self) -> &path::Path {


### PR DESCRIPTION
Sort options (sort criterion, reversion, dir-first, and case-sensitivity)
are specific for each tab. Changing sort-options will not have any
affect on tabs other than the currently active one. Each new tab will
start with the default sort-options.