### PR TITLE
use hashmap and uuid to store tabs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -392,6 +392,7 @@ dependencies = [
  "unicode-segmentation",
  "unicode-width",
  "users",
+ "uuid",
  "walkdir",
  "whoami",
  "xdg",
@@ -1101,6 +1102,28 @@ name = "utf8parse"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "936e4b492acfd135421d8dca4b1aa80a7bfc26e702ef3af710e0752684df5372"
+
+[[package]]
+name = "uuid"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd6469f4314d5f1ffec476e05f17cc9a78bc7a27a6a857842170bdf8d6f98d2f"
+dependencies = [
+ "getrandom",
+ "rand",
+ "uuid-macro-internal",
+]
+
+[[package]]
+name = "uuid-macro-internal"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "548f7181a5990efa50237abb7ebca410828b57a8955993334679f8b50b35c97d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "vec_map"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,14 @@ whoami = "^1"
 xdg = "^2"
 walkdir = "^2"
 
+[dependencies.uuid]
+version = "^1"
+features = [
+  "v4",
+  "fast-rng",
+  "macro-diagnostics",
+]
+
 [features]
 devicons = [ "phf" ]
 file_mimetype = []

--- a/src/commands/bulk_rename.rs
+++ b/src/commands/bulk_rename.rs
@@ -127,6 +127,6 @@ pub fn bulk_rename(context: &mut AppContext, backend: &mut AppBackend) -> Joshut
     backend.terminal_drop();
     let res = _bulk_rename(context);
     backend.terminal_restore()?;
-    reload::reload(context, context.tab_context_ref().index)?;
+    reload::soft_reload_curr_tab(context)?;
     res
 }

--- a/src/commands/change_directory.rs
+++ b/src/commands/change_directory.rs
@@ -51,7 +51,7 @@ pub fn parent_directory(context: &mut AppContext) -> JoshutoResult {
             .tab_context_mut()
             .curr_tab_mut()
             .set_cwd(parent.as_path());
-        reload::soft_reload(context.tab_context_ref().index, context)?;
+        reload::soft_reload_curr_tab(context)?;
     }
     Ok(())
 }
@@ -65,7 +65,7 @@ pub fn previous_directory(context: &mut AppContext) -> JoshutoResult {
             .tab_context_mut()
             .curr_tab_mut()
             .set_cwd(path.as_path());
-        reload::soft_reload(context.tab_context_ref().index, context)?;
+        reload::soft_reload_curr_tab(context)?;
     }
     Ok(())
 }

--- a/src/commands/delete_files.rs
+++ b/src/commands/delete_files.rs
@@ -80,10 +80,10 @@ fn _delete_selected_files(
     let curr_tab = context.tab_context_ref().curr_tab_ref();
     let options = context.config_ref().display_options_ref().clone();
     let curr_path = curr_tab.cwd().to_path_buf();
-    let tab_option = curr_tab.option_ref().clone();
-    for tab in context.tab_context_mut().iter_mut() {
+    for (_, tab) in context.tab_context_mut().iter_mut() {
+        let tab_options = tab.option_ref().clone();
         tab.history_mut()
-            .reload(&curr_path, &options, &tab_option)?;
+            .reload(&curr_path, &options, &tab_options)?;
     }
     Ok(())
 }
@@ -102,10 +102,10 @@ fn _delete_selected_files_background(
     let curr_tab = context.tab_context_ref().curr_tab_ref();
     let options = context.config_ref().display_options_ref().clone();
     let curr_path = curr_tab.cwd().to_path_buf();
-    let tab_option = curr_tab.option_ref().clone();
-    for tab in context.tab_context_mut().iter_mut() {
+    for (_, tab) in context.tab_context_mut().iter_mut() {
+        let tab_options = tab.option_ref().clone();
         tab.history_mut()
-            .reload(&curr_path, &options, &tab_option)?;
+            .reload(&curr_path, &options, &tab_options)?;
     }
     Ok(())
 }

--- a/src/commands/flat.rs
+++ b/src/commands/flat.rs
@@ -75,7 +75,6 @@ pub fn flatten(depth: usize, context: &mut AppContext) -> JoshutoResult {
     }
 
     let sort_options = tab_options.sort_options_ref();
-
     contents.sort_by(|f1, f2| sort_options.compare(f1, f2));
 
     let metadata = JoshutoMetadata::from(path.as_path())?;

--- a/src/commands/new_directory.rs
+++ b/src/commands/new_directory.rs
@@ -7,13 +7,9 @@ use crate::history::DirectoryHistory;
 pub fn new_directory(context: &mut AppContext, p: &path::Path) -> JoshutoResult {
     std::fs::create_dir_all(p)?;
     let options = context.config_ref().display_options_ref().clone();
-    let tab_options = context
-        .tab_context_ref()
-        .curr_tab_ref()
-        .option_ref()
-        .clone();
     let curr_path = context.tab_context_ref().curr_tab_ref().cwd().to_path_buf();
-    for tab in context.tab_context_mut().iter_mut() {
+    for (_, tab) in context.tab_context_mut().iter_mut() {
+        let tab_options = tab.option_ref().clone();
         tab.history_mut()
             .reload(&curr_path, &options, &tab_options)?;
     }

--- a/src/commands/open_file.rs
+++ b/src/commands/open_file.rs
@@ -130,7 +130,7 @@ pub fn open(context: &mut AppContext, backend: &mut AppBackend) -> JoshutoResult
         Some(entry) if entry.file_path().is_dir() => {
             let path = entry.file_path().to_path_buf();
             change_directory::cd(path.as_path(), context)?;
-            reload::soft_reload(context.tab_context_ref().index, context)?;
+            reload::soft_reload_curr_tab(context)?;
         }
         Some(entry) => {
             if context.args.file_chooser {

--- a/src/commands/show_hidden.rs
+++ b/src/commands/show_hidden.rs
@@ -11,7 +11,7 @@ pub fn _toggle_hidden(context: &mut AppContext) {
         .display_options_mut()
         .set_show_hidden(opposite);
 
-    for tab in context.tab_context_mut().iter_mut() {
+    for (_, tab) in context.tab_context_mut().iter_mut() {
         tab.history_mut().depreciate_all_entries();
         if let Some(s) = tab.curr_list_mut() {
             s.depreciate();
@@ -21,5 +21,6 @@ pub fn _toggle_hidden(context: &mut AppContext) {
 
 pub fn toggle_hidden(context: &mut AppContext) -> JoshutoResult {
     _toggle_hidden(context);
-    reload::reload_dirlist(context)
+    reload::soft_reload_curr_tab(context)?;
+    Ok(())
 }

--- a/src/commands/sort.rs
+++ b/src/commands/sort.rs
@@ -24,6 +24,6 @@ pub fn toggle_reverse(context: &mut AppContext) -> JoshutoResult {
 }
 
 fn refresh(context: &mut AppContext) -> JoshutoResult {
-    reload::soft_reload(context.tab_context_ref().index, context)?;
+    reload::soft_reload_curr_tab(context)?;
     Ok(())
 }

--- a/src/commands/sub_process.rs
+++ b/src/commands/sub_process.rs
@@ -55,7 +55,7 @@ pub fn sub_process(
 ) -> JoshutoResult {
     backend.terminal_drop();
     let res = execute_sub_process(context, words, spawn);
-    reload::soft_reload(context.tab_context_ref().index, context)?;
+    reload::soft_reload_curr_tab(context)?;
     context.message_queue_mut().push_info(format!(
         "{}: {}",
         if spawn { "Spawned" } else { "Finished" },

--- a/src/context/tab_context.rs
+++ b/src/context/tab_context.rs
@@ -1,50 +1,59 @@
-use std::slice::IterMut;
+use std::collections::hash_map::IterMut;
+use std::collections::HashMap;
+
+use uuid::Uuid;
 
 use crate::tab::JoshutoTab;
 
 #[derive(Default)]
 pub struct TabContext {
     pub index: usize,
-    tabs: Vec<JoshutoTab>,
+    pub tab_order: Vec<Uuid>,
+    tabs: HashMap<Uuid, JoshutoTab>,
 }
 
 impl TabContext {
     pub fn new() -> Self {
         Self::default()
     }
-
     pub fn len(&self) -> usize {
-        self.tabs.len()
+        self.tab_order.len()
     }
 
-    pub fn tab_ref(&self, i: usize) -> Option<&JoshutoTab> {
-        if i >= self.tabs.len() {
-            return None;
-        }
-        Some(&self.tabs[i])
+    pub fn tab_ref(&self, id: &Uuid) -> Option<&JoshutoTab> {
+        self.tabs.get(id)
     }
-    pub fn tab_mut(&mut self, i: usize) -> Option<&mut JoshutoTab> {
-        if i >= self.tabs.len() {
-            return None;
-        }
-        Some(&mut self.tabs[i])
+    pub fn tab_mut(&mut self, id: &Uuid) -> Option<&mut JoshutoTab> {
+        self.tabs.get_mut(id)
     }
 
+    pub fn curr_tab_id(&self) -> Uuid {
+        self.tab_order[self.index]
+    }
     pub fn curr_tab_ref(&self) -> &JoshutoTab {
-        &self.tabs[self.index]
+        let id = &self.tab_order[self.index];
+        self.tabs.get(id).unwrap()
     }
     pub fn curr_tab_mut(&mut self) -> &mut JoshutoTab {
-        &mut self.tabs[self.index]
+        let id = &self.tab_order[self.index];
+        self.tabs.get_mut(id).unwrap()
     }
-    pub fn push_tab(&mut self, tab: JoshutoTab) {
-        self.tabs.push(tab);
-        self.index = self.tabs.len() - 1;
+    pub fn insert_tab(&mut self, id: Uuid, tab: JoshutoTab) {
+        self.tabs.insert(id, tab);
+        self.tab_order.push(id);
     }
-    pub fn pop_tab(&mut self, index: usize) -> JoshutoTab {
-        self.tabs.remove(index)
+    pub fn remove_tab(&mut self, id: &Uuid) -> Option<JoshutoTab> {
+        let tab = self.tabs.remove(id);
+        for i in 0..self.tab_order.len() {
+            if self.tab_order[i] == *id {
+                self.tab_order.remove(i);
+                break;
+            }
+        }
+        tab
     }
 
-    pub fn iter_mut(&mut self) -> IterMut<JoshutoTab> {
+    pub fn iter_mut(&mut self) -> IterMut<Uuid, JoshutoTab> {
         self.tabs.iter_mut()
     }
 }

--- a/src/run.rs
+++ b/src/run.rs
@@ -12,6 +12,8 @@ use crate::ui;
 use crate::ui::views;
 use crate::ui::views::TuiView;
 
+use uuid::Uuid;
+
 use termion::event::{Event, Key};
 use tui::layout::Rect;
 
@@ -28,13 +30,14 @@ pub fn run_loop(
     }
 
     {
+        let id = Uuid::new_v4();
         // Initialize an initial tab
         let tab = JoshutoTab::new(
             curr_path,
             context.ui_context_ref(),
             context.config_ref().display_options_ref(),
         )?;
-        context.tab_context_mut().push_tab(tab);
+        context.tab_context_mut().insert_tab(id, tab);
 
         // trigger a preview of child
         preview_default::load_preview(context);

--- a/src/tab/homepage.rs
+++ b/src/tab/homepage.rs
@@ -1,0 +1,6 @@
+#[derive(Clone, Copy, Debug)]
+pub enum TabHomePage {
+    Inherit,
+    Home,
+    Root,
+}

--- a/src/tab/mod.rs
+++ b/src/tab/mod.rs
@@ -1,0 +1,5 @@
+mod homepage;
+mod tab_struct;
+
+pub use self::homepage::*;
+pub use self::tab_struct::*;

--- a/src/tab/tab_struct.rs
+++ b/src/tab/tab_struct.rs
@@ -5,18 +5,11 @@ use crate::context::UiContext;
 use crate::fs::JoshutoDirList;
 use crate::history::{DirectoryHistory, JoshutoHistory};
 
-#[derive(Clone, Copy, Debug)]
-pub enum TabHomePage {
-    Inherit,
-    Home,
-    Root,
-}
-
 pub struct JoshutoTab {
-    history: JoshutoHistory,
     _cwd: path::PathBuf,
     // history is just a HashMap, so we have this property to store last workdir
     _previous_dir: Option<path::PathBuf>,
+    history: JoshutoHistory,
     options: TabDisplayOption,
 }
 
@@ -51,7 +44,6 @@ impl JoshutoTab {
     pub fn cwd(&self) -> &path::Path {
         self._cwd.as_path()
     }
-
     pub fn set_cwd(&mut self, cwd: &path::Path) {
         self._previous_dir = Some(self._cwd.to_path_buf());
         self._cwd = cwd.to_path_buf();
@@ -68,7 +60,6 @@ impl JoshutoTab {
     pub fn history_ref(&self) -> &JoshutoHistory {
         &self.history
     }
-
     pub fn history_mut(&mut self) -> &mut JoshutoHistory {
         &mut self.history
     }
@@ -76,12 +67,10 @@ impl JoshutoTab {
     pub fn curr_list_ref(&self) -> Option<&JoshutoDirList> {
         self.history.get(self.cwd())
     }
-
     pub fn parent_list_ref(&self) -> Option<&JoshutoDirList> {
         let parent = self.cwd().parent()?;
         self.history.get(parent)
     }
-
     pub fn child_list_ref(&self) -> Option<&JoshutoDirList> {
         let curr_list = self.curr_list_ref()?;
         let index = curr_list.get_index()?;
@@ -92,12 +81,10 @@ impl JoshutoTab {
     pub fn curr_list_mut(&mut self) -> Option<&mut JoshutoDirList> {
         self.history.get_mut(self._cwd.as_path())
     }
-
     pub fn parent_list_mut(&mut self) -> Option<&mut JoshutoDirList> {
         let parent = self._cwd.parent()?;
         self.history.get_mut(parent)
     }
-
     #[allow(dead_code)]
     pub fn child_list_mut(&mut self) -> Option<&mut JoshutoDirList> {
         let child_path = {

--- a/src/ui/views/tui_folder_view.rs
+++ b/src/ui/views/tui_folder_view.rs
@@ -33,6 +33,7 @@ impl<'a> Widget for TuiFolderView<'a> {
     fn render(self, area: Rect, buf: &mut Buffer) {
         let preview_context = self.context.preview_context_ref();
         let curr_tab = self.context.tab_context_ref().curr_tab_ref();
+        let curr_tab_id = self.context.tab_context_ref().curr_tab_id();
 
         let curr_list = curr_tab.curr_list_ref();
         let child_list = curr_tab.child_list_ref();
@@ -180,13 +181,9 @@ impl<'a> Widget for TuiFolderView<'a> {
                 width: TAB_VIEW_WIDTH,
                 height: 1,
             };
-            let name = if let Some(ostr) = curr_tab.cwd().file_name() {
-                ostr.to_str().unwrap_or("")
-            } else {
-                ""
-            };
+            let name = curr_tab_id.to_string();
             TuiTabBar::new(
-                name,
+                &name[..5],
                 self.context.tab_context_ref().index,
                 self.context.tab_context_ref().len(),
             )

--- a/src/ui/views/tui_hsplit_view.rs
+++ b/src/ui/views/tui_hsplit_view.rs
@@ -26,7 +26,6 @@ impl<'a> TuiHSplitView<'a> {
 impl<'a> Widget for TuiHSplitView<'a> {
     fn render(self, area: Rect, buf: &mut Buffer) {
         let tab_context = self.context.tab_context_ref();
-        let tab_index = tab_context.index;
 
         let config = self.context.config_ref();
         let display_options = config.display_options_ref();
@@ -66,7 +65,9 @@ impl<'a> Widget for TuiHSplitView<'a> {
             calculate_layout(area, constraints)
         };
 
-        if let Some(curr_tab) = tab_context.tab_ref(tab_index) {
+        let tab_id = tab_context.curr_tab_id();
+        let tab_index = tab_context.index;
+        if let Some(curr_tab) = tab_context.tab_ref(&tab_id) {
             let curr_list = curr_tab.curr_list_ref();
 
             let layout_rect = if tab_index % 2 == 0 {
@@ -143,7 +144,8 @@ impl<'a> Widget for TuiHSplitView<'a> {
             tab_index - 1
         };
 
-        if let Some(curr_tab) = tab_context.tab_ref(other_tab_index) {
+        let other_tab_id = tab_context.tab_order[other_tab_index];
+        if let Some(curr_tab) = tab_context.tab_ref(&other_tab_id) {
             let curr_list = curr_tab.curr_list_ref();
 
             let layout_rect = if other_tab_index % 2 == 0 {


### PR DESCRIPTION
This is preliminary changes in order to track preview threads and progress.

The current setup is we just kick off a new thread to load
the given directory whenever we see the directory content
does not exist in history.
We don't track these threads or which tab these requests
came from. When the result is returned, we just assign it
to the current tab, instead of the tab that actually
initiated the request.

By adding uuid, we can now track which tab requested the
preview and assign it accordingly.
This will also allow us to track the status of the preview,
so we can display to the user a loading state,
when a directory is taking longer than usual to load.
This will also solve the problem of kicking off multiple
threads to read the same directory for the same tab.
Now these threads can be stored and tracked.

 - side: fix reload not honouring tab sort options @DLFW 
   - use tab specific options whenever we need to reload stuff