### PR TITLE
Rework filter and flat commands to be dirlist specific

### DIFF
--- a/docs/configuration/keymap.toml.md
+++ b/docs/configuration/keymap.toml.md
@@ -224,6 +224,8 @@ function joshuto() {
     - `--deselect=true`: deselect rather than select
     - `glob`: select files based on glob (just like `search_glob`)
        - `select *.png`
+ - `filter`:Case insensitively filter the current directory list.
+    - `:filter ca`: filter the current directory and show only items with `ca` in the name
 
 ## Integration
  - `bulk_rename`: rename all selected files

--- a/src/commands/escape.rs
+++ b/src/commands/escape.rs
@@ -1,16 +1,9 @@
 use crate::context::AppContext;
 use crate::error::JoshutoResult;
 
-use super::reload;
-
 pub fn escape(context: &mut AppContext) -> JoshutoResult {
     if let Some(curr_dir_list) = context.tab_context_mut().curr_tab_mut().curr_list_mut() {
-        if curr_dir_list.get_visual_mode_anchor_index().is_some() {
-            curr_dir_list.visual_mode_cancel();
-        } else {
-            // reload to clear current filter
-            reload::reload_dirlist(context)?;
-        }
+        curr_dir_list.visual_mode_cancel();
     };
     Ok(())
 }

--- a/src/commands/filter.rs
+++ b/src/commands/filter.rs
@@ -5,7 +5,11 @@ use super::reload;
 
 pub fn filter(context: &mut AppContext, arg: &str) -> JoshutoResult {
     let curr_tab = context.tab_context_mut().curr_tab_mut();
-    curr_tab.option_mut().set_filter_string(arg);
+    let path = curr_tab.cwd().to_path_buf();
+    curr_tab
+        .option_mut()
+        .dirlist_options_mut(&path)
+        .set_filter_string(arg);
 
     if let Some(list) = curr_tab.curr_list_mut() {
         list.depreciate();

--- a/src/commands/flat.rs
+++ b/src/commands/flat.rs
@@ -1,92 +1,20 @@
-use std::io;
-use std::path::Path;
-
-use crate::config::option::DisplayOption;
 use crate::context::AppContext;
 use crate::error::JoshutoResult;
-use crate::fs::{JoshutoDirEntry, JoshutoDirList, JoshutoMetadata};
 
-use walkdir::WalkDir;
-
-fn _is_hidden(entry: &walkdir::DirEntry) -> bool {
-    entry
-        .file_name()
-        .to_str()
-        .map(|s| s.starts_with('.'))
-        .unwrap_or(false)
-}
-
-pub fn _walk_directory(
-    path: &Path,
-    options: &DisplayOption,
-    depth: usize,
-) -> io::Result<Vec<JoshutoDirEntry>> {
-    let results: Vec<JoshutoDirEntry> = WalkDir::new(path)
-        .max_depth(depth)
-        .into_iter()
-        .filter_entry(|e| {
-            if options.show_hidden() {
-                true
-            } else {
-                !_is_hidden(e)
-            }
-        })
-        .filter(|e| {
-            if let Ok(e) = e.as_ref() {
-                e.path().to_str().cmp(&path.to_str()).is_ne()
-            } else {
-                true
-            }
-        })
-        .filter_map(|res| JoshutoDirEntry::from_walk(&res.ok()?, path, options).ok())
-        .collect();
-
-    Ok(results)
-}
+use super::reload;
 
 pub fn flatten(context: &mut AppContext, depth: usize) -> JoshutoResult {
-    let path = context.tab_context_ref().curr_tab_ref().cwd().to_path_buf();
+    let curr_tab = context.tab_context_mut().curr_tab_mut();
+    let path = curr_tab.cwd().to_path_buf();
+    curr_tab
+        .option_mut()
+        .dirlist_options_mut(&path)
+        .set_depth(depth as u8);
 
-    let options = context.config_ref().display_options_ref().clone();
-    let tab_options = context
-        .tab_context_ref()
-        .curr_tab_ref()
-        .option_ref()
-        .clone();
-
-    let mut index: Option<usize> = context
-        .tab_context_ref()
-        .curr_tab_ref()
-        .curr_list_ref()
-        .map(|lst| lst.get_index())
-        .unwrap_or_default();
-    let viewport_index: usize = context
-        .tab_context_ref()
-        .curr_tab_ref()
-        .curr_list_ref()
-        .map(|lst| lst.first_index_for_viewport())
-        .unwrap_or(0);
-
-    let mut contents = _walk_directory(path.as_path(), &options, depth)?;
-    let history = context.tab_context_mut().curr_tab_mut().history_mut();
-
-    if contents.is_empty() {
-        index = None;
+    if let Some(list) = curr_tab.curr_list_mut() {
+        list.depreciate();
     }
 
-    let sort_options = tab_options.sort_options_ref();
-    contents.sort_by(|f1, f2| sort_options.compare(f1, f2));
-
-    let metadata = JoshutoMetadata::from(path.as_path())?;
-    let dirlist = JoshutoDirList::new(
-        path.clone(),
-        contents,
-        index,
-        viewport_index,
-        None,
-        metadata,
-    );
-    history.insert(path, dirlist);
-
+    reload::soft_reload_curr_tab(context)?;
     Ok(())
 }

--- a/src/commands/reload.rs
+++ b/src/commands/reload.rs
@@ -92,12 +92,6 @@ pub fn reload(context: &mut AppContext, id: &Uuid) -> std::io::Result<()> {
 }
 
 pub fn reload_dirlist(context: &mut AppContext) -> JoshutoResult {
-    // clear filter on reload
-    context
-        .tab_context_mut()
-        .curr_tab_mut()
-        .option_mut()
-        .set_filter_string("");
     reload(context, &context.tab_context_ref().curr_tab_id())?;
     Ok(())
 }

--- a/src/config/general/display_raw.rs
+++ b/src/config/general/display_raw.rs
@@ -125,7 +125,7 @@ impl From<DisplayOptionRaw> for DisplayOption {
             no_preview_layout,
             default_tab_display_option: TabDisplayOption {
                 _sort_options: raw.sort_options.into(),
-                filter_string: "".to_owned(),
+                ..Default::default()
             },
         }
     }

--- a/src/config/option/display_option.rs
+++ b/src/config/option/display_option.rs
@@ -67,8 +67,6 @@ impl DirListDisplayOptions {
     pub fn set_depth(&mut self, depth: u8) {
         self.depth = depth;
     }
-46
-    pub _sort_options: SortOption,
 
     pub fn depth(&self) -> u8 {
         self.depth
@@ -178,10 +176,7 @@ impl std::default::Default for DisplayOption {
             _line_nums: LineNumberStyle::None,
             default_layout,
             no_preview_layout,
-            default_tab_display_option: TabDisplayOption {
-                linemode: LineMode::Size,
-                ..Default::default()
-            },
+            default_tab_display_option: TabDisplayOption::default(),
         }
     }
 }

--- a/src/config/option/display_option.rs
+++ b/src/config/option/display_option.rs
@@ -1,4 +1,4 @@
-use std::fs;
+use std::{collections::HashMap, path::PathBuf};
 
 use tui::layout::Constraint;
 
@@ -32,11 +32,18 @@ pub struct DisplayOption {
     pub default_tab_display_option: TabDisplayOption,
 }
 
+/// Display options valid pre JoshutoDirList in a JoshutoTab
+#[derive(Clone, Debug, Default)]
+pub struct DirListDisplayOptions {
+    filter_string: String,
+    depth: u8,
+}
+
 /// Display options valid per JoshutoTab
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct TabDisplayOption {
     pub _sort_options: SortOption,
-    pub filter_string: String,
+    pub dirlist_options: HashMap<PathBuf, DirListDisplayOptions>,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -44,6 +51,24 @@ pub enum LineNumberStyle {
     None,
     Relative,
     Absolute,
+}
+
+impl DirListDisplayOptions {
+    pub fn set_filter_string(&mut self, pattern: &str) {
+        self.filter_string = pattern.to_owned();
+    }
+
+    pub fn filter_string_ref(&self) -> &str {
+        &self.filter_string
+    }
+
+    pub fn set_depth(&mut self, depth: u8) {
+        self.depth = depth;
+    }
+
+    pub fn depth(&self) -> u8 {
+        self.depth
+    }
 }
 
 impl TabDisplayOption {
@@ -55,12 +80,16 @@ impl TabDisplayOption {
         &mut self._sort_options
     }
 
-    pub fn set_filter_string(&mut self, pattern: &str) {
-        self.filter_string = pattern.to_owned();
+    pub fn dirlist_options_ref(&self, path: &PathBuf) -> Option<&DirListDisplayOptions> {
+        self.dirlist_options.get(path)
     }
 
-    pub fn filter_string_ref(&self) -> &str {
-        &self.filter_string
+    pub fn dirlist_options_mut(&mut self, path: &PathBuf) -> &mut DirListDisplayOptions {
+        if !self.dirlist_options.contains_key(path) {
+            self.dirlist_options
+                .insert(path.to_owned(), Default::default());
+        }
+        self.dirlist_options.get_mut(path).unwrap()
     }
 }
 
@@ -111,7 +140,7 @@ impl DisplayOption {
 
     pub fn filter_func(
         &self,
-    ) -> fn(&Result<fs::DirEntry, std::io::Error>, &DisplayOption, &TabDisplayOption) -> bool {
+    ) -> fn(&walkdir::DirEntry, &DisplayOption, &DirListDisplayOptions) -> bool {
         filter
     }
 }
@@ -145,50 +174,43 @@ impl std::default::Default for DisplayOption {
             _line_nums: LineNumberStyle::None,
             default_layout,
             no_preview_layout,
-            default_tab_display_option: TabDisplayOption {
-                _sort_options: SortOption::default(),
-                filter_string: "".to_owned(),
-            },
+            default_tab_display_option: TabDisplayOption::default(),
         }
     }
 }
 
-fn has_str(entry: &fs::DirEntry, pat: &str) -> bool {
-    match entry.file_name().into_string().ok() {
-        Some(s) => s
-            .to_ascii_lowercase()
-            .contains(pat.to_ascii_lowercase().as_str()),
-        None => false,
-    }
+fn has_str(entry: &walkdir::DirEntry, pat: &str) -> bool {
+    entry
+        .file_name()
+        .to_str()
+        .map(|s| {
+            s.to_ascii_lowercase()
+                .as_str()
+                .contains(pat.to_ascii_lowercase().as_str())
+        })
+        .unwrap_or(false)
+}
+
+fn is_hidden(entry: &walkdir::DirEntry) -> bool {
+    entry
+        .file_name()
+        .to_str()
+        .map(|s| s.starts_with('.'))
+        .unwrap_or(false)
 }
 
 fn filter(
-    result: &Result<fs::DirEntry, std::io::Error>,
+    entry: &walkdir::DirEntry,
     opt: &DisplayOption,
-    tab_opts: &TabDisplayOption,
+    dirlist_opts: &DirListDisplayOptions,
 ) -> bool {
-    if opt.show_hidden() && tab_opts.filter_string_ref().is_empty() {
+    if opt.show_hidden() && dirlist_opts.filter_string_ref().is_empty() {
         true
+    } else if dirlist_opts.filter_string_ref().is_empty() {
+        !is_hidden(entry)
+    } else if opt.show_hidden() || !is_hidden(entry) {
+        has_str(entry, dirlist_opts.filter_string_ref())
     } else {
-        match result {
-            Err(_) => true,
-            Ok(entry) => {
-                if tab_opts.filter_string_ref().is_empty() {
-                    let file_name = entry.file_name();
-                    let lossy_string = file_name.as_os_str().to_string_lossy();
-                    !lossy_string.starts_with('.')
-                } else if opt.show_hidden() {
-                    has_str(entry, tab_opts.filter_string_ref())
-                } else {
-                    let file_name = entry.file_name();
-                    let lossy_string = file_name.as_os_str().to_string_lossy();
-                    if !lossy_string.starts_with('.') {
-                        has_str(entry, tab_opts.filter_string_ref())
-                    } else {
-                        false
-                    }
-                }
-            }
-        }
+        false
     }
 }

--- a/src/config/option/linemodes.rs
+++ b/src/config/option/linemodes.rs
@@ -1,7 +1,8 @@
 use crate::error::{JoshutoError, JoshutoErrorKind, JoshutoResult};
 
-#[derive(Clone, Debug, Copy)]
+#[derive(Clone, Debug, Copy, Default)]
 pub enum LineMode {
+    #[default]
     Size,
     MTime,
     SizeMTime,

--- a/src/key_command/impl_from_str.rs
+++ b/src/key_command/impl_from_str.rs
@@ -363,7 +363,7 @@ impl std::str::FromStr for Command {
             Ok(Self::SwitchLineNums(policy))
         } else if command == CMD_FLAT {
             match arg.parse::<usize>() {
-                Ok(i) => Ok(Self::Flat { depth: i + 1 }),
+                Ok(i) => Ok(Self::Flat { depth: i }),
                 Err(e) => Err(JoshutoError::new(
                     JoshutoErrorKind::InvalidParameters,
                     format!("{}: {}", command, e),

--- a/src/ui/views/tui_textfield.rs
+++ b/src/ui/views/tui_textfield.rs
@@ -168,7 +168,14 @@ impl<'a> TuiTextField<'a> {
                 match event {
                     AppEvent::Termion(Event::Key(key)) => {
                         let dirty = match key {
-                            Key::Backspace => line_buffer.backspace(1),
+                            Key::Backspace => {
+                                let res = line_buffer.backspace(1);
+
+                                if let Ok(command) = Command::from_str(line_buffer.as_str()) {
+                                    command.interactive_execute(context)
+                                }
+                                res
+                            }
                             Key::Delete => line_buffer.delete(1).is_some(),
                             Key::Home => line_buffer.move_home(),
                             Key::End => line_buffer.move_end(),


### PR DESCRIPTION
- `filter` and `flat` commands are now specific to directory list and refreshing wouldn't reset the commands.
- Pressing "backspace" now updates on interactive commands.
