### PR TITLE
update ansi-to-tui to 2.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,10 +28,12 @@ dependencies = [
 
 [[package]]
 name = "ansi-to-tui"
-version = "0.6.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ef15b7b32ef426166ba4f153a0ade6fb3b81b20ff3d2cdbc89c369f5a2e620"
+checksum = "3460d7beaf8b192c09a55933da038ccd514f00efdb37d7d87f3ce078336b47e9"
 dependencies = [
+ "nom",
+ "thiserror",
  "tui",
 ]
 
@@ -508,6 +510,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "mio"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -539,6 +547,16 @@ dependencies = [
  "cfg-if",
  "libc",
  "memoffset",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 keywords = ["tui-rs", "ranger", "file manager", "termion"]
 
 [dependencies]
-ansi-to-tui = { version = "^0", optional = true }
+ansi-to-tui = { version = "^2", optional = true }
 alphanumeric-sort = "^1"
 chrono = "^0"
 colors-transform = "^0"

--- a/src/ui/widgets/tui_file_preview.rs
+++ b/src/ui/widgets/tui_file_preview.rs
@@ -29,9 +29,9 @@ impl<'a> TuiFilePreview<'a> {
 
     #[cfg(feature = "syntax_highlight")]
     fn render_text_preview(&self, area: Rect, buf: &mut Buffer, s: &str) {
-        use ansi_to_tui::ansi_to_text;
+        use ansi_to_tui::IntoText;
         let vec = s.as_bytes().to_vec();
-        let res = ansi_to_text(vec);
+        let res = vec.into_text();
 
         match res {
             Ok(text) => {


### PR DESCRIPTION
updated ansi-to-tui to 2.0.0 which has much better ansi parsing.
ansi-to-tui 0.6.0:
![2022-10-21-181304_498x288_scrot](https://user-images.githubusercontent.com/41364823/197247568-d51f9675-8592-4a3c-a37d-7a79aa2a2abe.png)

ansi-to-tui 2.0.0:
![2022-10-21-181344_494x296_scrot](https://user-images.githubusercontent.com/41364823/197247665-57c379fb-b8d4-4f0f-baca-8f6f32f48465.png)
