### PR TITLE
Added `rename_keep_ext` command and refactored rename functions

### DIFF
--- a/docs/configuration/keymap.toml.md
+++ b/docs/configuration/keymap.toml.md
@@ -211,6 +211,8 @@ function joshuto() {
     (end of file name if no extension)
  - `rename_prepend`: opens the command prompt with the rename command and the current file name filled in.
     - cursor will be set to the beginning of the file name
+ - `rename_keep_ext`: opens the command prompt with the rename command and the extension of the current file filled in.
+    - cursor will be set right before the extension of the file
 
  - `copy_filename`: copy the file name to clipboard
     - clipboard support requires xsel, xclip, or wl-copy

--- a/src/commands/rename_file.rs
+++ b/src/commands/rename_file.rs
@@ -68,18 +68,15 @@ pub fn rename_file_append(
     backend: &mut AppBackend,
     keymap_t: &AppKeyMapping,
 ) -> JoshutoResult {
-    match _get_current_file_name(context) {
-        Some(file_name) => {
-            let (prefix, suffix): (String, String) = match file_name.rfind('.') {
-                Some(ext) => (
-                    format!("rename {}", &file_name[0..ext]),
-                    file_name[ext..].to_string(),
-                ),
-                None => (format!("rename {}", file_name), "".to_string()),
-            };
-            command_line::read_and_execute(context, backend, keymap_t, &prefix, &suffix)?;
-        }
-        None => {}
+    if let Some(file_name) = _get_current_file_name(context) {
+        let (prefix, suffix): (String, String) = match file_name.rfind('.') {
+            Some(ext) => (
+                format!("rename {}", &file_name[0..ext]),
+                file_name[ext..].to_string(),
+            ),
+            None => (format!("rename {}", file_name), "".to_string()),
+        };
+        command_line::read_and_execute(context, backend, keymap_t, &prefix, &suffix)?;
     }
     Ok(())
 }
@@ -89,12 +86,9 @@ pub fn rename_file_prepend(
     backend: &mut AppBackend,
     keymap_t: &AppKeyMapping,
 ) -> JoshutoResult {
-    match _get_current_file_name(context) {
-        Some(file_name) => {
-            let (prefix, suffix) = ("rename ".to_string(), file_name);
-            command_line::read_and_execute(context, backend, keymap_t, &prefix, &suffix)?;
-        }
-        None => {}
+    if let Some(file_name) = _get_current_file_name(context) {
+        let (prefix, suffix) = ("rename ".to_string(), file_name);
+        command_line::read_and_execute(context, backend, keymap_t, &prefix, &suffix)?;
     }
     Ok(())
 }
@@ -104,15 +98,12 @@ pub fn rename_file_keep_ext(
     backend: &mut AppBackend,
     keymap_t: &AppKeyMapping,
 ) -> JoshutoResult {
-    match _get_current_file_name(context) {
-        Some(file_name) => {
-            let (prefix, suffix): (String, String) = match file_name.rfind('.') {
-                Some(ext) => ("rename ".to_string(), file_name[ext..].to_string()),
-                None => ("rename ".to_string(), "".to_string()),
-            };
-            command_line::read_and_execute(context, backend, keymap_t, &prefix, &suffix)?;
-        }
-        None => {}
+    if let Some(file_name) = _get_current_file_name(context) {
+        let (prefix, suffix): (String, String) = match file_name.rfind('.') {
+            Some(ext) => ("rename ".to_string(), file_name[ext..].to_string()),
+            None => ("rename ".to_string(), "".to_string()),
+        };
+        command_line::read_and_execute(context, backend, keymap_t, &prefix, &suffix)?;
     }
     Ok(())
 }

--- a/src/commands/rename_file.rs
+++ b/src/commands/rename_file.rs
@@ -55,20 +55,12 @@ pub fn rename_file(context: &mut AppContext, dest: &path::Path) -> JoshutoResult
     Ok(())
 }
 
-pub fn _rename_file_append(
-    context: &mut AppContext,
-    backend: &mut AppBackend,
-    keymap_t: &AppKeyMapping,
-    file_name: &str,
-) -> JoshutoResult {
-    let (prefix, suffix): (String, String) = match file_name.rfind('.') {
-        Some(ext) => (
-            format!("rename {}", &file_name[0..ext]),
-            file_name[ext..].to_string(),
-        ),
-        None => (format!("rename {}", file_name), "".to_string()),
-    };
-    command_line::read_and_execute(context, backend, keymap_t, &prefix, &suffix)
+fn _get_current_file_name(context: &mut AppContext) -> Option<String> {
+    context
+        .tab_context_ref()
+        .curr_tab_ref()
+        .curr_list_ref()
+        .and_then(|list| list.curr_entry_ref().map(|s| s.file_name().to_string()))
 }
 
 pub fn rename_file_append(
@@ -76,29 +68,20 @@ pub fn rename_file_append(
     backend: &mut AppBackend,
     keymap_t: &AppKeyMapping,
 ) -> JoshutoResult {
-    let mut file_name: Option<String> = None;
-
-    if let Some(curr_list) = context.tab_context_ref().curr_tab_ref().curr_list_ref() {
-        file_name = curr_list
-            .curr_entry_ref()
-            .map(|s| s.file_name().to_string());
-    }
-
-    if let Some(file_name) = file_name {
-        _rename_file_append(context, backend, keymap_t, file_name.as_str())?;
+    match _get_current_file_name(context) {
+        Some(file_name) => {
+            let (prefix, suffix): (String, String) = match file_name.rfind('.') {
+                Some(ext) => (
+                    format!("rename {}", &file_name[0..ext]),
+                    file_name[ext..].to_string(),
+                ),
+                None => (format!("rename {}", file_name), "".to_string()),
+            };
+            command_line::read_and_execute(context, backend, keymap_t, &prefix, &suffix)?;
+        }
+        None => {}
     }
     Ok(())
-}
-
-pub fn _rename_file_prepend(
-    context: &mut AppContext,
-    backend: &mut AppBackend,
-    keymap_t: &AppKeyMapping,
-    file_name: String,
-) -> JoshutoResult {
-    let prefix = String::from("rename ");
-    let suffix = file_name;
-    command_line::read_and_execute(context, backend, keymap_t, &prefix, &suffix)
 }
 
 pub fn rename_file_prepend(
@@ -106,14 +89,30 @@ pub fn rename_file_prepend(
     backend: &mut AppBackend,
     keymap_t: &AppKeyMapping,
 ) -> JoshutoResult {
-    let file_name = context
-        .tab_context_ref()
-        .curr_tab_ref()
-        .curr_list_ref()
-        .and_then(|list| list.curr_entry_ref().map(|s| s.file_name().to_string()));
+    match _get_current_file_name(context) {
+        Some(file_name) => {
+            let (prefix, suffix) = ("rename ".to_string(), file_name);
+            command_line::read_and_execute(context, backend, keymap_t, &prefix, &suffix)?;
+        }
+        None => {}
+    }
+    Ok(())
+}
 
-    if let Some(file_name) = file_name {
-        _rename_file_prepend(context, backend, keymap_t, file_name)?;
+pub fn rename_file_keep_ext(
+    context: &mut AppContext,
+    backend: &mut AppBackend,
+    keymap_t: &AppKeyMapping,
+) -> JoshutoResult {
+    match _get_current_file_name(context) {
+        Some(file_name) => {
+            let (prefix, suffix): (String, String) = match file_name.rfind('.') {
+                Some(ext) => ("rename ".to_string(), file_name[ext..].to_string()),
+                None => ("rename ".to_string(), "".to_string()),
+            };
+            command_line::read_and_execute(context, backend, keymap_t, &prefix, &suffix)?;
+        }
+        None => {}
     }
     Ok(())
 }

--- a/src/key_command/command.rs
+++ b/src/key_command/command.rs
@@ -86,6 +86,7 @@ pub enum Command {
     },
     RenameFileAppend,
     RenameFilePrepend,
+    RenameFileKeepExt,
     TouchFile {
         file_name: String,
     },

--- a/src/key_command/constants.rs
+++ b/src/key_command/constants.rs
@@ -54,6 +54,7 @@ cmd_constants![
     (CMD_RENAME_FILE, "rename"),
     (CMD_RENAME_FILE_APPEND, "rename_append"),
     (CMD_RENAME_FILE_PREPEND, "rename_prepend"),
+    (CMD_RENAME_FILE_KEEP_EXT, "rename_keep_ext"),
     (CMD_SEARCH_STRING, "search"),
     (CMD_SEARCH_INCREMENTAL, "search_inc"),
     (CMD_SEARCH_GLOB, "search_glob"),

--- a/src/key_command/impl_appcommand.rs
+++ b/src/key_command/impl_appcommand.rs
@@ -56,6 +56,7 @@ impl AppCommand for Command {
             Self::RenameFile { .. } => CMD_RENAME_FILE,
             Self::RenameFileAppend => CMD_RENAME_FILE_APPEND,
             Self::RenameFilePrepend => CMD_RENAME_FILE_PREPEND,
+            Self::RenameFileKeepExt => CMD_RENAME_FILE_KEEP_EXT,
 
             Self::SearchString { .. } => CMD_SEARCH_STRING,
             Self::SearchIncremental { .. } => CMD_SEARCH_INCREMENTAL,

--- a/src/key_command/impl_appexecute.rs
+++ b/src/key_command/impl_appexecute.rs
@@ -92,6 +92,9 @@ impl AppExecute for Command {
             Self::RenameFile { new_name } => rename_file::rename_file(context, new_name.as_path()),
             Self::RenameFileAppend => rename_file::rename_file_append(context, backend, keymap_t),
             Self::RenameFilePrepend => rename_file::rename_file_prepend(context, backend, keymap_t),
+            Self::RenameFileKeepExt => {
+                rename_file::rename_file_keep_ext(context, backend, keymap_t)
+            }
             Self::TouchFile { file_name } => touch_file::touch_file(context, file_name),
             Self::SearchGlob { pattern } => search_glob::search_glob(context, pattern.as_str()),
             Self::SearchString { pattern } => {

--- a/src/key_command/impl_comment.rs
+++ b/src/key_command/impl_comment.rs
@@ -82,6 +82,7 @@ impl CommandComment for Command {
             Self::TouchFile { .. } => "Touch file",
             Self::RenameFileAppend => "Rename a file",
             Self::RenameFilePrepend => "Rename a file",
+            Self::RenameFileKeepExt => "Rename a file",
 
             Self::SearchString { .. } => "Search",
             Self::SearchIncremental { .. } => "Search as you type",

--- a/src/key_command/impl_from_str.rs
+++ b/src/key_command/impl_from_str.rs
@@ -77,6 +77,7 @@ impl std::str::FromStr for Command {
         simple_command_conversion_case!(command, CMD_RELOAD_DIRECTORY_LIST, Self::ReloadDirList);
         simple_command_conversion_case!(command, CMD_RENAME_FILE_APPEND, Self::RenameFileAppend);
         simple_command_conversion_case!(command, CMD_RENAME_FILE_PREPEND, Self::RenameFilePrepend);
+        simple_command_conversion_case!(command, CMD_RENAME_FILE_KEEP_EXT, Self::RenameFileKeepExt);
         simple_command_conversion_case!(command, CMD_SEARCH_NEXT, Self::SearchNext);
         simple_command_conversion_case!(command, CMD_SEARCH_PREV, Self::SearchPrev);
         simple_command_conversion_case!(command, CMD_SHOW_TASKS, Self::ShowTasks);


### PR DESCRIPTION
Added the `rename_keep_ext` command as discussed in #214.
Refactoring: removed unnecessary code duplication with helper function `_get_current_file_name` and added some match statements for cleaner code (e.g. a `None => {}` more clearly indicates that nothing should be done in that case).