### PR TITLE
config option for close_tab quit action

### DIFF
--- a/src/commands/quit.rs
+++ b/src/commands/quit.rs
@@ -22,6 +22,13 @@ impl QuitAction {
             Self::OutputSelectedFiles => 102,
         }
     }
+    pub fn from_str(s: &str) -> Option<Self> {
+        match s {
+            "noop" => Some(Self::Noop),
+            "outputdir" => Some(Self::OutputCurrentDirectory),
+            _ => None,
+        }
+    }
 }
 
 pub fn quit_with_action(context: &mut AppContext, quit_action: QuitAction) -> JoshutoResult {

--- a/src/commands/tab_ops.rs
+++ b/src/commands/tab_ops.rs
@@ -118,7 +118,7 @@ pub fn new_tab(context: &mut AppContext) -> JoshutoResult {
 
 pub fn close_tab(context: &mut AppContext) -> JoshutoResult {
     if context.tab_context_ref().len() <= 1 {
-        return quit_with_action(context, QuitAction::Noop);
+        return quit_with_action(context, context.config_ref().tab_options_ref().tab_quit_action());
     }
     let curr_tab_id = context.tab_context_ref().curr_tab_id();
     let mut tab_index = context.tab_context_ref().index;

--- a/src/config/general/tab_raw.rs
+++ b/src/config/general/tab_raw.rs
@@ -36,7 +36,7 @@ impl From<TabOptionRaw> for TabOption {
         let home_page =
             TabHomePage::from_str(raw.home_page.as_str()).unwrap_or_else(|| TabHomePage::Home);
         let tab_quit_action =
-            QuitAction::from_str(&raw.tab_quit_action.as_str()).unwrap_or_else(|| QuitAction::Noop);
+            QuitAction::from_str(raw.tab_quit_action.as_str()).unwrap_or_else(|| QuitAction::Noop);
 
         Self::new(home_page, tab_quit_action)
     }

--- a/src/config/general/tab_raw.rs
+++ b/src/config/general/tab_raw.rs
@@ -4,21 +4,29 @@ use serde_derive::Deserialize;
 
 use crate::config::option::TabOption;
 use crate::tab::TabHomePage;
+use crate::QuitAction;
 
 fn default_home_page() -> String {
     "home".to_string()
+}
+
+fn default_tab_quit_action() -> String {
+    "noop".to_string()
 }
 
 #[derive(Clone, Debug, Deserialize)]
 pub struct TabOptionRaw {
     #[serde(default = "default_home_page")]
     pub home_page: String,
+    #[serde(default = "default_tab_quit_action")]
+    pub tab_quit_action: String,
 }
 
 impl std::default::Default for TabOptionRaw {
     fn default() -> Self {
         Self {
             home_page: default_home_page(),
+            tab_quit_action: default_tab_quit_action(),
         }
     }
 }
@@ -27,7 +35,9 @@ impl From<TabOptionRaw> for TabOption {
     fn from(raw: TabOptionRaw) -> Self {
         let home_page =
             TabHomePage::from_str(raw.home_page.as_str()).unwrap_or_else(|| TabHomePage::Home);
+        let tab_quit_action =
+            QuitAction::from_str(&raw.tab_quit_action.as_str()).unwrap_or_else(|| QuitAction::Noop);
 
-        Self::new(home_page)
+        Self::new(home_page, tab_quit_action)
     }
 }

--- a/src/config/option/tab_option.rs
+++ b/src/config/option/tab_option.rs
@@ -1,16 +1,21 @@
 use crate::tab::TabHomePage;
+use crate::QuitAction;
 
 #[derive(Clone, Debug)]
 pub struct TabOption {
     pub _home_page: TabHomePage,
+    pub _tab_quit_action: QuitAction
 }
 
 impl TabOption {
-    pub fn new(_home_page: TabHomePage) -> Self {
-        Self { _home_page }
+    pub fn new(_home_page: TabHomePage, _tab_quit_action: QuitAction) -> Self {
+        Self { _home_page, _tab_quit_action }
     }
     pub fn home_page(&self) -> TabHomePage {
         self._home_page
+    }
+    pub fn tab_quit_action(&self) -> QuitAction {
+        self._tab_quit_action
     }
 }
 
@@ -18,6 +23,7 @@ impl std::default::Default for TabOption {
     fn default() -> Self {
         Self {
             _home_page: TabHomePage::Home,
+            _tab_quit_action: QuitAction::Noop,
         }
     }
 }


### PR DESCRIPTION
I added a configuration option for what happens when you exit joshuto through the close_tab command rather than the quit command. The default is noop, as the regular behavior, but I like to have it do the "output directory" action.