### PR TITLE
Bulk-rename works with only current file

### DIFF
--- a/src/commands/bulk_rename.rs
+++ b/src/commands/bulk_rename.rs
@@ -39,7 +39,7 @@ pub fn _bulk_rename(context: &mut AppContext) -> JoshutoResult {
         .tab_context_ref()
         .curr_tab_ref()
         .curr_list_ref()
-        .map_or(vec![], |s| s.iter_selected().collect());
+        .map_or(vec![], |s| s.selected_or_current());
 
     /* write file names into temporary file to edit */
     {

--- a/src/fs/dirlist.rs
+++ b/src/fs/dirlist.rs
@@ -241,6 +241,19 @@ impl JoshutoDirList {
         self.contents.get_mut(self.index?)
     }
 
+    /// Returns a vector with all selected files or - if no files are selected - with
+    /// only the "current" entry. If there is neither a selection nor a current file
+    /// (when this `JoshutoDirList` is empty), the returned vector will also be empty.
+    pub fn selected_or_current(&self) -> Vec<&JoshutoDirEntry> {
+        let mut entries: Vec<&JoshutoDirEntry> = self.iter_selected().collect();
+        if entries.is_empty() {
+            if let Some(curr_entry) = self.curr_entry_ref() {
+                entries.push(curr_entry)
+            }
+        }
+        entries
+    }
+
     /// Returns the index of the first entry to be printed in a UI dir list
     pub fn first_index_for_viewport(&self) -> usize {
         self.viewport_index


### PR DESCRIPTION
If no file is selected, bulk-rename will use the "current" file (the one with the cursor) for renaming.

Adds method `JoshutoDirList.selected_or_current -> Vec<&JoshutoDirEntry>` which can be used anywhere to get this a collection of selected files _or_ the current one if none is selected.