### PR TITLE
Add option to override deleting to trash

### DIFF
--- a/docs/configuration/keymap.toml.md
+++ b/docs/configuration/keymap.toml.md
@@ -217,6 +217,7 @@ function joshuto() {
  - `paste_files`: move/copy files stored from a previous `cut_files` or `copy_files` command
  - `delete_files`: delete selected files (or current file if none were selected).
     - `--foreground=true`: will delete files in the foreground
+    - `--permanently`: force permanent deletion regardless of `use_trash` value.
     - will ***permanently*** delete files if `use_trash` is `false` in
     [joshuto.toml](https://github.com/kamiyaa/joshuto)/wiki/Configuration#joshutotoml)
     - if `use_trash` is `true`, this might cause issues with deleting files

--- a/src/commands/delete_files.rs
+++ b/src/commands/delete_files.rs
@@ -14,6 +14,7 @@ fn delete_files(
     context: &mut AppContext,
     backend: &mut AppBackend,
     background: bool,
+    permanently: bool,
 ) -> std::io::Result<()> {
     let paths = context
         .tab_context_ref()
@@ -53,7 +54,7 @@ fn delete_files(
                 let options = FileOperationOptions {
                     overwrite: false,
                     skip_exist: false,
-                    permanently: !context.config_ref().use_trash,
+                    permanently: !context.config_ref().use_trash || permanently,
                 };
 
                 let dest = path::PathBuf::new();
@@ -71,49 +72,21 @@ fn delete_files(
     }
 }
 
-fn _delete_selected_files(
+pub fn delete_selected_files(
     context: &mut AppContext,
     backend: &mut AppBackend,
-) -> std::io::Result<()> {
-    delete_files(context, backend, false)?;
-
-    let curr_tab = context.tab_context_ref().curr_tab_ref();
-    let options = context.config_ref().display_options_ref().clone();
-    let curr_path = curr_tab.cwd().to_path_buf();
-    for (_, tab) in context.tab_context_mut().iter_mut() {
-        let tab_options = tab.option_ref().clone();
-        tab.history_mut()
-            .reload(&curr_path, &options, &tab_options)?;
-    }
-    Ok(())
-}
-
-pub fn delete_selected_files(context: &mut AppContext, backend: &mut AppBackend) -> JoshutoResult {
-    _delete_selected_files(context, backend)?;
-    Ok(())
-}
-
-fn _delete_selected_files_background(
-    context: &mut AppContext,
-    backend: &mut AppBackend,
-) -> std::io::Result<()> {
-    delete_files(context, backend, true)?;
-
-    let curr_tab = context.tab_context_ref().curr_tab_ref();
-    let options = context.config_ref().display_options_ref().clone();
-    let curr_path = curr_tab.cwd().to_path_buf();
-    for (_, tab) in context.tab_context_mut().iter_mut() {
-        let tab_options = tab.option_ref().clone();
-        tab.history_mut()
-            .reload(&curr_path, &options, &tab_options)?;
-    }
-    Ok(())
-}
-
-pub fn delete_selected_files_background(
-    context: &mut AppContext,
-    backend: &mut AppBackend,
+    background: bool,
+    permanently: bool,
 ) -> JoshutoResult {
-    _delete_selected_files(context, backend)?;
+    delete_files(context, backend, background, permanently)?;
+
+    let curr_tab = context.tab_context_ref().curr_tab_ref();
+    let options = context.config_ref().display_options_ref().clone();
+    let curr_path = curr_tab.cwd().to_path_buf();
+    for (_, tab) in context.tab_context_mut().iter_mut() {
+        let tab_options = tab.option_ref().clone();
+        tab.history_mut()
+            .reload(&curr_path, &options, &tab_options)?;
+    }
     Ok(())
 }

--- a/src/key_command/command.rs
+++ b/src/key_command/command.rs
@@ -37,6 +37,7 @@ pub enum Command {
 
     DeleteFiles {
         background: bool,
+        permanently: bool,
     },
 
     CursorMoveUp {

--- a/src/key_command/impl_appexecute.rs
+++ b/src/key_command/impl_appexecute.rs
@@ -47,12 +47,10 @@ impl AppExecute for Command {
             Self::SymlinkFiles { relative: false } => file_ops::symlink_absolute(context),
             Self::PasteFiles { options } => file_ops::paste(context, *options),
 
-            Self::DeleteFiles { background: false } => {
-                delete_files::delete_selected_files(context, backend)
-            }
-            Self::DeleteFiles { background: true } => {
-                delete_files::delete_selected_files_background(context, backend)
-            }
+            Self::DeleteFiles {
+                background,
+                permanently,
+            } => delete_files::delete_selected_files(context, backend, *background, *permanently),
 
             Self::CursorMoveUp { offset } => cursor_move::up(context, *offset),
             Self::CursorMoveDown { offset } => cursor_move::down(context, *offset),

--- a/src/key_command/impl_display.rs
+++ b/src/key_command/impl_display.rs
@@ -24,8 +24,21 @@ impl std::fmt::Display for Command {
                 write!(f, "{} --relative={}", self.command(), relative)
             }
             Self::PasteFiles { options } => write!(f, "{}  {}", self.command(), options),
-            Self::DeleteFiles { background: false } => {
-                write!(f, "{} --foreground=true", self.command(),)
+            Self::DeleteFiles {
+                background,
+                permanently,
+            } => {
+                write!(
+                    f,
+                    "{}{}{}",
+                    self.command(),
+                    if !background {
+                        " --foreground=true"
+                    } else {
+                        ""
+                    },
+                    if *permanently { " --permanently" } else { "" }
+                )
             }
 
             Self::RenameFile { new_name } => write!(f, "{} {:?}", self.command(), new_name),

--- a/src/key_command/impl_from_str.rs
+++ b/src/key_command/impl_from_str.rs
@@ -243,14 +243,24 @@ impl std::str::FromStr for Command {
             }
             Ok(Self::PasteFiles { options })
         } else if command == CMD_DELETE_FILES {
-            match arg {
-                "--foreground=true" => Ok(Self::DeleteFiles { background: true }),
-                "--foreground=false" => Ok(Self::DeleteFiles { background: false }),
-                _ => Err(JoshutoError::new(
-                    JoshutoErrorKind::UnrecognizedArgument,
-                    format!("{}: unknown option '{}'", command, arg),
-                )),
+            let (mut permanently, mut background) = (false, true);
+            for arg in arg.split_whitespace() {
+                match arg {
+                    "--foreground=true" => background = true,
+                    "--foreground=false" => background = false,
+                    "--permanently" => permanently = true,
+                    _ => {
+                        return Err(JoshutoError::new(
+                            JoshutoErrorKind::UnrecognizedArgument,
+                            format!("{}: unknown option '{}'", command, arg),
+                        ))
+                    }
+                }
             }
+            Ok(Self::DeleteFiles {
+                background,
+                permanently,
+            })
         } else if command == CMD_RENAME_FILE {
             match arg {
                 "" => Err(JoshutoError::new(


### PR DESCRIPTION
Add the `--permanently` option to the `delete_files` command to delete files permanently when `use_trash` is `true`.