### PR TITLE
Help search also inside description column

### DIFF
--- a/src/ui/widgets/tui_help.rs
+++ b/src/ui/widgets/tui_help.rs
@@ -130,14 +130,20 @@ pub fn get_raw_keymap_table<'a>(
                 for _ in 0..sub_rows.len() {
                     let mut sub_row = sub_rows.pop().unwrap();
                     sub_row[0] = key.clone() + &sub_row[0];
-                    if sub_row[0].contains(search_query) || sub_row[1].contains(search_query) || sub_row[2].to_lowercase().contains(search_query_lowercase) {
+                    if sub_row[0].contains(search_query)
+                        || sub_row[1].contains(search_query)
+                        || sub_row[2].to_lowercase().contains(search_query_lowercase)
+                    {
                         rows.push(sub_row)
                     }
                 }
                 continue;
             }
         };
-        if key.contains(search_query) || command.contains(search_query) || comment.to_lowercase().contains(search_query_lowercase){
+        if key.contains(search_query)
+            || command.contains(search_query)
+            || comment.to_lowercase().contains(search_query_lowercase)
+        {
             rows.push([key, command, comment.to_string()]);
         }
     }

--- a/src/ui/widgets/tui_help.rs
+++ b/src/ui/widgets/tui_help.rs
@@ -119,6 +119,7 @@ pub fn get_raw_keymap_table<'a>(
     search_query: &'a str,
     sort_by: usize,
 ) -> Vec<[String; 3]> {
+    let search_query_lowercase = &String::from(search_query).to_lowercase();
     let mut rows = Vec::new();
     for (event, bind) in keymap.iter() {
         let key = key_event_to_string(event);
@@ -129,14 +130,14 @@ pub fn get_raw_keymap_table<'a>(
                 for _ in 0..sub_rows.len() {
                     let mut sub_row = sub_rows.pop().unwrap();
                     sub_row[0] = key.clone() + &sub_row[0];
-                    if sub_row[0].contains(search_query) || sub_row[1].contains(search_query) {
+                    if sub_row[0].contains(search_query) || sub_row[1].contains(search_query) || sub_row[2].to_lowercase().contains(search_query_lowercase) {
                         rows.push(sub_row)
                     }
                 }
                 continue;
             }
         };
-        if key.contains(search_query) || command.contains(search_query) {
+        if key.contains(search_query) || command.contains(search_query) || comment.to_lowercase().contains(search_query_lowercase){
             rows.push([key, command, comment.to_string()]);
         }
     }


### PR DESCRIPTION
I'm new to joshuto so use the Help view.
Currently when searching in the help using '/' it searches only the key and command columns. I actually need the search to search in the 'Description' column. 
So I modified the search code to search also in the Description column and do a case insensitive search.
