### PR TITLE
new_tab can open specific directories

### DIFF
--- a/config/keymap.toml
+++ b/config/keymap.toml
@@ -2,8 +2,9 @@
 
 keymap = [
 	{ keys = [ "escape" ],		command = "escape" },
-	{ keys = [ "T" ],		command = "new_tab" },
 	{ keys = [ "ctrl+t" ],		command = "new_tab" },
+	{ keys = [ "alt+t" ],		command = "new_tab --cursor" },
+	{ keys = [ "T" ],		command = "new_tab --current" },
 	{ keys = [ "W" ],		command = "close_tab" },
 	{ keys = [ "ctrl+w" ],		command = "close_tab" },
 	{ keys = [ "q" ],		command = "close_tab" },

--- a/docs/configuration/keymap.toml.md
+++ b/docs/configuration/keymap.toml.md
@@ -194,8 +194,13 @@ function joshuto() {
 
 
 ## Tabs
- - `new_tab`: opens a new tab
-    - new tab opens in home directory
+ - `new_tab [--current][--cursor][dir]`: opens a new tab
+    - `new_tab`, without any argument, opens a new tab with the default directory.
+
+      (Note: the default directory for new tabs is specified in `joshuto.toml` in the `tab` section.)
+    - `new_tab some-dir` opens new tab with directory `some-dir`
+    - `new_tab --current` opens new tab with the same directory as the current tab
+    - `new_tab --cursor` opens new tab with the directory which is currently marked by the cursor
  - `close_tab`: close current tab
  - `tab_switch`: switch to next/previous tab by `x`
     - where `x` is an integer

--- a/src/config/option/mod.rs
+++ b/src/config/option/mod.rs
@@ -1,5 +1,6 @@
 pub mod display_option;
 pub mod linemodes;
+pub mod new_tab_option;
 pub mod preview_option;
 pub mod select_option;
 pub mod sort_option;
@@ -8,6 +9,7 @@ pub mod tab_option;
 
 pub use self::display_option::*;
 pub use self::linemodes::*;
+pub use self::new_tab_option::*;
 pub use self::preview_option::*;
 pub use self::select_option::*;
 pub use self::sort_option::*;

--- a/src/config/option/new_tab_option.rs
+++ b/src/config/option/new_tab_option.rs
@@ -1,0 +1,19 @@
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub enum NewTabMode {
+    #[default]
+    Default,
+    CurrentTabDir,
+    CursorDir,
+    Directory(String),
+}
+
+impl NewTabMode {
+    pub fn from_str(arg: &str) -> NewTabMode {
+        match arg.trim() {
+            "" => NewTabMode::Default,
+            "--current" => NewTabMode::CurrentTabDir,
+            "--cursor" => NewTabMode::CursorDir,
+            dir => NewTabMode::Directory(String::from(dir)),
+        }
+    }
+}

--- a/src/key_command/command.rs
+++ b/src/key_command/command.rs
@@ -1,7 +1,7 @@
 use std::path;
 
 use crate::commands::quit::QuitAction;
-use crate::config::option::{LineMode, LineNumberStyle, SelectOption, SortType};
+use crate::config::option::{LineMode, LineNumberStyle, NewTabMode, SelectOption, SortType};
 use crate::io::FileOperationOptions;
 
 #[derive(Clone, Debug)]
@@ -132,7 +132,9 @@ pub enum Command {
         pattern: String,
     },
 
-    NewTab,
+    NewTab {
+        mode: NewTabMode,
+    },
     CloseTab,
     TabSwitch {
         offset: i32,

--- a/src/key_command/impl_appcommand.rs
+++ b/src/key_command/impl_appcommand.rs
@@ -17,7 +17,7 @@ impl AppCommand for Command {
             Self::ParentDirectory => CMD_PARENT_DIRECTORY,
             Self::PreviousDirectory => CMD_PREVIOUS_DIRECTORY,
 
-            Self::NewTab => CMD_NEW_TAB,
+            Self::NewTab { .. } => CMD_NEW_TAB,
             Self::CloseTab => CMD_CLOSE_TAB,
             Self::CommandLine { .. } => CMD_COMMAND_LINE,
 

--- a/src/key_command/impl_appexecute.rs
+++ b/src/key_command/impl_appexecute.rs
@@ -26,7 +26,7 @@ impl AppExecute for Command {
             Self::ParentDirectory => change_directory::parent_directory(context),
             Self::PreviousDirectory => change_directory::previous_directory(context),
 
-            Self::NewTab => tab_ops::new_tab(context),
+            Self::NewTab { mode } => tab_ops::new_tab(context, mode),
             Self::CloseTab => tab_ops::close_tab(context),
             Self::CommandLine { prefix, suffix } => command_line::read_and_execute(
                 context,

--- a/src/key_command/impl_comment.rs
+++ b/src/key_command/impl_comment.rs
@@ -21,7 +21,7 @@ impl CommandComment for Command {
             Self::ParentDirectory => "CD to parent directory",
             Self::PreviousDirectory => "CD to the last dir in history",
 
-            Self::NewTab => "Open a new tab",
+            Self::NewTab { .. } => "Open a new tab",
             Self::CloseTab => "Close current tab",
             Self::CommandLine { prefix, .. } => match prefix.trim() {
                 "cd" => "Change directory",

--- a/src/key_command/impl_from_str.rs
+++ b/src/key_command/impl_from_str.rs
@@ -1,7 +1,7 @@
 use std::path;
 
 use crate::commands::quit::QuitAction;
-use crate::config::option::{LineMode, LineNumberStyle, SelectOption, SortType};
+use crate::config::option::{LineMode, LineNumberStyle, NewTabMode, SelectOption, SortType};
 use crate::error::{JoshutoError, JoshutoErrorKind};
 use crate::io::FileOperationOptions;
 use crate::util::unix;
@@ -39,7 +39,6 @@ impl std::str::FromStr for Command {
 
         simple_command_conversion_case!(command, CMD_TOGGLE_VISUAL, Self::ToggleVisualMode);
 
-        simple_command_conversion_case!(command, CMD_NEW_TAB, Self::NewTab);
         simple_command_conversion_case!(command, CMD_CLOSE_TAB, Self::CloseTab);
 
         simple_command_conversion_case!(command, CMD_HELP, Self::Help);
@@ -101,6 +100,10 @@ impl std::str::FromStr for Command {
                 "--output-selected-files" => Ok(Self::Quit(QuitAction::OutputSelectedFiles)),
                 _ => Ok(Self::Quit(QuitAction::Noop)),
             }
+        } else if command == CMD_NEW_TAB {
+            Ok(Self::NewTab {
+                mode: NewTabMode::from_str(arg),
+            })
         } else if command == CMD_CHANGE_DIRECTORY {
             match arg {
                 "" => match HOME_DIR.as_ref() {


### PR DESCRIPTION
The `new_tab` command got enhanced and can now open a user-specified directory, or the directory of the current tab, or the directory currently highlighted by the cursor.

* `new_tab some-dir` opens new tab with directory `some-dir`
* `new_tab --current` opens new tab with the same directory as the current tab
* `new_tab --cursor` opens new tab with the directory which is currently marked by the cursor

The `keymap.toml` documentation got adapted accordingly.

The default key-map also got enhanced/changed:

* `ctrl-t`: opens tab in default directory
* `shift-t`: opens tab in directory of current tab
* `alt-t`: opens tab in directory marked by cursor

Like before, all new tabs get activated when created. Opening tabs “in the background” is a possible enhancement for the future and might be especially useful for the `--cursor` variant.