### PR TITLE
autocomplete: assume selection when there's only one candidate

### DIFF
--- a/docs/image_previews.md
+++ b/docs/image_previews.md
@@ -265,7 +265,7 @@ case "$mimetype" in
 esac
 ```
 
-`~/.config/joshuto/on_preview_removed.sh`:
+`~/.config/joshuto/on_preview_removed`:
 ```shell
 #!/usr/bin/env bash
 

--- a/src/key_command/impl_from_str.rs
+++ b/src/key_command/impl_from_str.rs
@@ -248,7 +248,6 @@ impl std::str::FromStr for Command {
         } else if command == CMD_DELETE_FILES {
             let (mut permanently, mut background) = (false, false);
             for arg in arg.split_whitespace() {
-                eprintln!("arg: {:?}", arg);
                 match arg {
                     "--background=true" => background = true,
                     "--background=false" => background = false,

--- a/src/ui/views/tui_textfield.rs
+++ b/src/ui/views/tui_textfield.rs
@@ -215,6 +215,10 @@ impl<'a> TuiTextField<'a> {
                                 let _ = terminal.hide_cursor();
                                 return None;
                             }
+                            Key::Ctrl('c') => {
+                                let _ = terminal.hide_cursor();
+                                return None;
+                            }
                             Key::Char('\t') => autocomplete(
                                 &mut line_buffer,
                                 &mut completion_tracker,

--- a/src/ui/views/tui_textfield.rs
+++ b/src/ui/views/tui_textfield.rs
@@ -324,9 +324,14 @@ fn autocomplete(
         };
 
         let candidate = &ct.candidates[ct.index];
-        completer.update(line_buffer, ct.pos, candidate.display());
+        completer.update(line_buffer, ct.pos, candidate.replacement());
     } else if let Some((pos, mut candidates)) = get_candidates(completer, line_buffer) {
         if !candidates.is_empty() {
+            if candidates.len() == 1 && candidates[0].replacement().ends_with('/') {
+                completer.update(line_buffer, pos, &candidates[0].replacement());
+                return false;
+            }
+
             candidates.sort_by(|x, y| {
                 x.display()
                     .partial_cmp(y.display())
@@ -334,7 +339,7 @@ fn autocomplete(
             });
 
             let first_idx = if reversed { candidates.len() - 1 } else { 0 };
-            let first = candidates[first_idx].display().to_string();
+            let first = candidates[first_idx].replacement().to_string();
 
             let mut ct =
                 CompletionTracker::new(pos, candidates, String::from(line_buffer.as_str()));

--- a/src/ui/views/tui_textfield.rs
+++ b/src/ui/views/tui_textfield.rs
@@ -317,10 +317,8 @@ fn autocomplete(
     if let Some(ref mut ct) = completion_tracker {
         ct.index = if reversed {
             ct.index.checked_sub(1).unwrap_or(ct.candidates.len() - 1)
-        } else if ct.index + 1 < ct.candidates.len() {
-            ct.index + 1
         } else {
-            ct.index
+            (ct.index + 1) % ct.candidates.len()
         };
 
         let candidate = &ct.candidates[ct.index];


### PR DESCRIPTION
This makes autocomplete behave like how it works in ranger. To test before and after, create a directory long directory chain `$HOME/foo/bar/baz`, type `:cd fo` and press Tab several times. Previously, joshuto would stop at `foo`, but now the first Tab will autocomplete `foo/`, the second will autocomplete `foo/bar/`, and so on.

I don't know any Rust, but the change seems to work. Feel free to cherry pick the commit and make changes to make it more idiomatic/cleaner/whatever.

The PR also includes a couple of other trivial improvements.