### PR TITLE
change dependency from tui to ratatui

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,13 +28,13 @@ dependencies = [
 
 [[package]]
 name = "ansi-to-tui"
-version = "2.0.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3460d7beaf8b192c09a55933da038ccd514f00efdb37d7d87f3ce078336b47e9"
+checksum = "5f3d156989cd98fb225b1a83e82e133e95a151774a420c884f6a65c5f6fb1ee2"
 dependencies = [
  "nom",
+ "ratatui",
  "thiserror",
- "tui",
 ]
 
 [[package]]
@@ -493,6 +493,7 @@ dependencies = [
  "open",
  "phf",
  "rand",
+ "ratatui",
  "rustyline",
  "serde",
  "serde_derive",
@@ -500,10 +501,9 @@ dependencies = [
  "shellexpand",
  "signal-hook",
  "structopt",
- "termion",
+ "termion 1.5.6",
  "toml",
  "trash",
- "tui",
  "unicode-segmentation",
  "unicode-width",
  "users",
@@ -872,6 +872,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ratatui"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d690717aac4aca6e901da642fafcceff63ded0ab4c65c18ceff39c9a27f21508"
+dependencies = [
+ "bitflags",
+ "cassowary",
+ "termion 2.0.1",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1117,6 +1130,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "termion"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "659c1f379f3408c7e5e84c7d0da6d93404e3800b6b9d063ba24436419302ec90"
+dependencies = [
+ "libc",
+ "numtoa",
+ "redox_syscall",
+ "redox_termios",
+]
+
+[[package]]
 name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1219,19 +1244,6 @@ dependencies = [
  "scopeguard",
  "url",
  "windows",
-]
-
-[[package]]
-name = "tui"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccdd26cbd674007e649a272da4475fb666d3aa0ad0531da7136db6fab0e5bad1"
-dependencies = [
- "bitflags",
- "cassowary",
- "termion",
- "unicode-segmentation",
- "unicode-width",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 keywords = ["tui-rs", "ranger", "file manager", "termion"]
 
 [dependencies]
-ansi-to-tui = { version = "^2", optional = true }
+ansi-to-tui = { version = "^3", optional = true }
 alphanumeric-sort = "^1"
 chrono = "^0"
 colors-transform = "^0"
@@ -33,7 +33,7 @@ structopt = "^0"
 termion = "^1"
 toml = "^0"
 trash = { version = "^2", optional = true }
-tui = { version = "^0", default-features = false, features = ["termion"] }
+tui = { version = "0.20", default-features = false, features = ["termion"], package = "ratatui" }
 unicode-segmentation = "^1"
 unicode-width = "^0"
 users = "^0"

--- a/src/ui/views/tui_folder_view.rs
+++ b/src/ui/views/tui_folder_view.rs
@@ -304,7 +304,8 @@ pub fn calculate_layout(area: Rect, constraints: &[Constraint; 3]) -> Vec<Rect> 
     let mut layout_rect = Layout::default()
         .direction(Direction::Horizontal)
         .constraints(constraints.as_ref())
-        .split(area);
+        .split(area)
+        .to_vec();
 
     layout_rect[0] = Rect {
         width: layout_rect[0].width - 1,

--- a/src/ui/views/tui_hsplit_view.rs
+++ b/src/ui/views/tui_hsplit_view.rs
@@ -159,7 +159,8 @@ fn calculate_layout(area: Rect, constraints: &[Constraint; 2]) -> Vec<Rect> {
     let mut layout_rect = Layout::default()
         .direction(Direction::Horizontal)
         .constraints(constraints.as_ref())
-        .split(area);
+        .split(area)
+        .to_vec();
 
     layout_rect[0] = Rect {
         width: layout_rect[0].width - 1,


### PR DESCRIPTION
#289 
This changes the tui depedency to the ratatui package and makes the versioning less permissive since breaking changes are likely coming on minor versions

This version of ratatui (0.20.1) should have parity with tui, thought it looks like there are some type issues that i had to fix as well. 

I tested this just by hopping into joshuto and going between files and dirs, opened a file using it, and creating some tabs. If there are more manual tests i should run lemme know. 

tested on 6.3.1-arch1-1