### PR TITLE
Add a new feature: fzf bookmarks

### DIFF
--- a/docs/configuration/keymap.toml.md
+++ b/docs/configuration/keymap.toml.md
@@ -287,6 +287,10 @@ When disabling, the current “visual mode selection” is turned into normal se
 ### `add_bookmark`: adds a bookmark to the `bookmarks.toml` file
 ### `cd_bookmark`: prompts a menu of bookmarks and navigates to selected bookmark
 
+### `fzf_add_mark <name>`: create a fzf bookmark entry in file `#HOME/.fzf-marks`, with the format `<name> : <current directory path>`.
+
+### `fzf_cd_mark`: open a fzf window to let user select an entry in `#HOME/.fzf-marks`, and cd to the selected directory.
+
 ## Integration
 ### `bulk_rename`: rename all selected files
 - this will create a file inside `$TMP_DIR` (or `/tmp` if `$TMP_DIR` is not set) and

--- a/src/commands/fzf_bookmarks.rs
+++ b/src/commands/fzf_bookmarks.rs
@@ -1,0 +1,104 @@
+use std::io::{self, Write};
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+
+use crate::context::AppContext;
+use crate::error::{JoshutoError, JoshutoErrorKind, JoshutoResult};
+use crate::ui::AppBackend;
+use crate::HOME_DIR;
+
+use std::fs::{File, OpenOptions};
+
+use super::change_directory::change_directory;
+
+pub fn fzf_add_bookmark(
+    _context: &mut AppContext,
+    _backend: &mut AppBackend,
+    bookmark_name: &String,
+) -> JoshutoResult {
+    if let Some(home_dir) = HOME_DIR.as_ref() {
+        let mut markfile_path = PathBuf::from(home_dir);
+        markfile_path.push(".fzf-marks");
+
+        if !markfile_path.exists() {
+            File::create(&markfile_path)?;
+        }
+
+        let bookmark_path = std::env::current_dir()?;
+
+        // let new_mark_str = format!(
+        //     "{} : {}",
+        //     bookmark_name,
+        //     bookmark_path.as_os_str().to_str().unwrap()
+        // );
+
+        let mut file = OpenOptions::new()
+            .write(true)
+            .append(true)
+            .open(markfile_path)
+            .unwrap();
+
+        if let Err(e) = writeln!(
+            file,
+            "{} : {}",
+            bookmark_name,
+            bookmark_path.as_os_str().to_str().unwrap()
+        ) {
+            eprintln!("Couldn't write to file: {}", e);
+        }
+    } else {
+        return Err(JoshutoError::new(
+            JoshutoErrorKind::EnvVarNotPresent,
+            format!("{}: Cannot find home directory", "fzf_cd_bookmark"),
+        ));
+    }
+
+    Ok(())
+}
+
+pub fn fzf_cd_bookmark(context: &mut AppContext, backend: &mut AppBackend) -> JoshutoResult {
+    if let Some(home_dir) = HOME_DIR.as_ref() {
+        let mut markfile_path = PathBuf::from(home_dir);
+        markfile_path.push(".fzf-marks");
+
+        if !markfile_path.exists() {
+            return Err(JoshutoError::new(
+                JoshutoErrorKind::Io(io::ErrorKind::NotFound),
+                String::from("There's no fzf bookmark! Create one first by fzf_add_bookmark."),
+            ));
+        }
+
+        backend.terminal_drop();
+
+        let cat_cmd = Command::new("cat")
+            .arg(markfile_path.as_os_str().to_str().unwrap())
+            .stdout(Stdio::piped())
+            .spawn()?;
+
+        let fzf = Command::new("fzf")
+            .stdin(Stdio::from(cat_cmd.stdout.unwrap()))
+            .stdout(Stdio::piped())
+            .spawn()?;
+
+        let fzf_output = fzf.wait_with_output();
+
+        match fzf_output {
+            Ok(output) if output.status.success() => {
+                if let Ok(selected) = std::str::from_utf8(&output.stdout) {
+                    if let Some((_, dir)) = selected.rsplit_once(':') {
+                        let path: PathBuf = PathBuf::from(dir.trim());
+                        change_directory(context, path.as_path())?;
+                    }
+                }
+            }
+            _ => {}
+        }
+        backend.terminal_restore()?;
+    } else {
+        return Err(JoshutoError::new(
+            JoshutoErrorKind::EnvVarNotPresent,
+            format!("{}: Cannot find home directory", "fzf_cd_bookmark"),
+        ));
+    }
+    Ok(())
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -8,6 +8,7 @@ pub mod escape;
 pub mod file_ops;
 pub mod filter;
 pub mod flat;
+pub mod fzf_bookmarks;
 pub mod line_nums;
 pub mod linemode;
 pub mod new_directory;

--- a/src/key_command/command.rs
+++ b/src/key_command/command.rs
@@ -151,4 +151,9 @@ pub enum Command {
 
     BookmarkAdd,
     BookmarkChangeDirectory,
+
+    FzfBookmarkAdd {
+        bookmark_name: String,
+    },
+    FzfBookmarkCd,
 }

--- a/src/key_command/constants.rs
+++ b/src/key_command/constants.rs
@@ -85,6 +85,8 @@ cmd_constants![
     (CMD_FILTER, "filter"),
     (CMD_BOOKMARK_ADD, "add_bookmark"),
     (CMD_BOOKMARK_CHANGE_DIRECTORY, "cd_bookmark"),
+    (CMD_FZF_ADD_BOOKMARK, "fzf_add_mark"),
+    (CMD_FZF_CD_BOOKMARK, "fzf_cd_mark"),
 ];
 
 pub fn complete_command(partial_command: &str) -> Vec<Pair> {

--- a/src/key_command/impl_appcommand.rs
+++ b/src/key_command/impl_appcommand.rs
@@ -94,6 +94,9 @@ impl AppCommand for Command {
 
             Self::BookmarkAdd => CMD_BOOKMARK_ADD,
             Self::BookmarkChangeDirectory => CMD_BOOKMARK_CHANGE_DIRECTORY,
+
+            Self::FzfBookmarkAdd { .. } => CMD_FZF_ADD_BOOKMARK,
+            Self::FzfBookmarkCd => CMD_FZF_CD_BOOKMARK,
         }
     }
 }

--- a/src/key_command/impl_appexecute.rs
+++ b/src/key_command/impl_appexecute.rs
@@ -142,6 +142,11 @@ impl AppExecute for Command {
 
             Self::BookmarkAdd => bookmark::add_bookmark(context, backend),
             Self::BookmarkChangeDirectory => bookmark::change_directory_bookmark(context, backend),
+
+            Self::FzfBookmarkAdd { bookmark_name } => {
+                fzf_bookmarks::fzf_add_bookmark(context, backend, bookmark_name)
+            }
+            Self::FzfBookmarkCd => fzf_bookmarks::fzf_cd_bookmark(context, backend),
         }
     }
 }

--- a/src/key_command/impl_comment.rs
+++ b/src/key_command/impl_comment.rs
@@ -125,6 +125,9 @@ impl CommandComment for Command {
 
             Self::BookmarkAdd => "Add a bookmark",
             Self::BookmarkChangeDirectory => "Navigate to a bookmark",
+
+            Self::FzfBookmarkAdd { .. } => "Add a fzf bookmark",
+            Self::FzfBookmarkCd => "Navigate to a fzf bookmark",
         }
     }
 }

--- a/src/key_command/impl_from_str.rs
+++ b/src/key_command/impl_from_str.rs
@@ -93,6 +93,8 @@ impl std::str::FromStr for Command {
         simple_command_conversion_case!(command, CMD_ZOXIDE, Self::Zoxide(arg.to_string()));
         simple_command_conversion_case!(command, CMD_ZOXIDE_INTERACTIVE, Self::ZoxideInteractive);
 
+        simple_command_conversion_case!(command, CMD_FZF_CD_BOOKMARK, Self::FzfBookmarkCd);
+
         if command == CMD_QUIT {
             match arg {
                 "--force" => Ok(Self::Quit(QuitAction::Force)),
@@ -401,6 +403,10 @@ impl std::str::FromStr for Command {
         } else if command == CMD_FILTER {
             Ok(Self::Filter {
                 pattern: arg.to_string(),
+            })
+        } else if command == CMD_FZF_ADD_BOOKMARK {
+            Ok(Self::FzfBookmarkAdd {
+                bookmark_name: arg.to_string(),
             })
         } else {
             Err(JoshutoError::new(


### PR DESCRIPTION
I'm implementing fzf bookmarks inspired from [ranger-fzf-marks](https://github.com/laggardkernel/ranger-fzf-marks), which is a plugin I use everyday in ranger, and I'd like to have it as well in joshuto.

It acts as follows:

- `fzf_add_mark [markname]` creates a new line in file `$HOME/.fzf-marks`, with the format `markname : current_directory`.
- `fzf_cd_mark` opens a `fzf` selection window to select a bookmark, and then `cd` to that directory in joshuto.

See it in the following video:

https://github.com/kamiyaa/joshuto/assets/49983642/e33f197c-74d9-4559-8663-c8972e54bfa3
