### PR TITLE
Tab theme configurable

### DIFF
--- a/config/theme.toml
+++ b/config/theme.toml
@@ -1,7 +1,24 @@
+##########################################
+## Tabs
+##########################################
+
+# Inactive tabs
+[tabs.inactive]
+
+# Active tabs
+[tabs.active]
+invert=true
+
+##########################################
+## File List - Selections
+##########################################
+
+# Selected files (standard selection)
 [selection]
 fg = "light_yellow"
 bold = true
 
+# Files selected in current visual mode
 [visual_mode_selection]
 fg = "light_red"
 bold = true
@@ -10,28 +27,49 @@ bold = true
 prefix = "  "
 size = 2
 
-[executable]
-fg = "light_green"
-bold = true
+##########################################
+## File List - System File Types
+##########################################
 
+# Basic style, used for regular files (and also device files and FIFOs)
 [regular]
 fg = "white"
 
+# For directories
 [directory]
 fg = "light_blue"
 bold = true
 
+# For symbolic links
 [link]
 fg = "cyan"
 bold = true
 
+# For socket files
+[socket]
+fg = "light_magenta"
+bold = true
+
+##########################################
+## File List - Exceptional Files
+##########################################
+
+# Files marked as executable
+[executable]
+fg = "light_green"
+bold = true
+
+# Invalid symbolic links (pointing to non-existing target)
 [link_invalid]
 fg = "red"
 bold = true
 
-[socket]
-fg = "light_magenta"
-bold = true
+##########################################
+## File list - Override style by extension
+##########################################
+# This sections allows to override the basic 
+# style with a specific style for the file's
+# extension.
 
 [ext]
 

--- a/docs/configuration/theme.toml.md
+++ b/docs/configuration/theme.toml.md
@@ -1,11 +1,14 @@
 # theme.toml
 
-This file is used to theme joshuto
+This file is used to theme Joshuto.
 
-## Style
+As of now, all theming items are "text style" items where one can define the
+background color and the foreground color, and enable some font attributes.
 
-Each style has the following fields:
 
+## Style options
+
+Each style allows the following fields:
 ```toml
 # background color
 bg = "light_blue"
@@ -15,81 +18,46 @@ bold = false
 underline = false
 invert = false
 ```
+Each field is optional. If omitted, it defaults to the terminal default.
+
 
 ## Color
 
-Joshuto supports 16 colors as well as hex colors via `rgb(r,g,b)`
+Joshuto supports 16 colors as well as hex colors via `rgb(r,g,b)`.
+The 16 default colors are:
+* `black`
+* `red`
+* `blue`
+* `green`
+* `yellow`
+* `magenta`
+* `cyan`
+* `white`
+* `gray`
+* `dark_gray`
+* `light_red`
+* `light_green`
+* `light_yellow`
+* `light_blue`
+* `light_magenta`
+* `light_cyan`
 
-```
-black
-red
-blue
-green
-yellow
-magenta
-cyan
-white
-gray
-dark_gray
-light_red
-light_green
-light_yellow
-light_blue
-light_magenta
-light_cyan
-_
-```
 
-## Theme
+## Configuration Items
 
-joshuto supports theming via system file types as well as extensions
+You can find a complete list of the available configuration items with their default
+values and short explanations as comment in 
+[`theme.toml`](https://github.com/kamiyaa/joshuto/blob/main/config/theme.toml).
 
-System file types include:
+In general, `theme.toml` allows to specify the style of a few UI "widgets",
+and the file entries in the file lists.
 
-```toml
-# for selected files
-[selection]
-fg = "light_yellow"
-bold = true
+The file entries can be styled by their basic system file type and by their extension.
+The extension-specific style overrides the basic style.
 
-# for executable files
-[executable]
-fg = "light_green"
-bold = true
+Special file entries (as of now, executable files and invalid symlinks) have
+a specific style that overrides the former file-type-styles.
 
-# default theme
-[regular]
-fg = "white"
+Last but not least, there are styles for _selected_ files which override all the former
+styles.
 
-# for directories
-[directory]
-fg = "light_blue"
-bold = true
-
-# for symlinks
-[link]
-fg = "cyan"
-bold = true
-
-# for invalid symlinks
-[link_invalid]
-fg = "red"
-bold = true
-
-# for sockets
-[socket]
-fg = "light_magenta"
-bold = true
-```
-
-Via extensions
-
-```toml
-[ext]
-[ext.jpg]
-fg = "yellow"
-[ext.jpeg]
-fg = "yellow"
-[ext.png]
-fg = "yellow"
-```

--- a/src/config/theme/app_theme.rs
+++ b/src/config/theme/app_theme.rs
@@ -9,6 +9,8 @@ use crate::error::JoshutoResult;
 #[derive(Clone, Debug, Deserialize, Default)]
 pub struct AppThemeRaw {
     #[serde(default)]
+    pub tabs: TabThemeRaw,
+    #[serde(default)]
     pub regular: AppStyleRaw,
     #[serde(default)]
     pub selection: AppStyleRaw,
@@ -28,8 +30,25 @@ pub struct AppThemeRaw {
     pub ext: HashMap<String, AppStyleRaw>,
 }
 
+#[derive(Clone, Debug, Deserialize, Default)]
+pub struct TabThemeRaw {
+    #[serde(default)]
+    pub inactive: AppStyleRaw,
+    #[serde(default)]
+    pub active: AppStyleRaw,
+}
+
+impl From<TabThemeRaw> for TabTheme {
+    fn from(crude: TabThemeRaw) -> Self {
+        let inactive = crude.inactive.to_style_theme();
+        let active = crude.active.to_style_theme();
+        Self { inactive, active }
+    }
+}
+
 impl From<AppThemeRaw> for AppTheme {
     fn from(crude: AppThemeRaw) -> Self {
+        let tabs = crude.tabs;
         let selection = crude.selection.to_style_theme();
         let visual_mode_selection = crude.visual_mode_selection.to_style_theme();
         let executable = crude.executable.to_style_theme();
@@ -57,12 +76,14 @@ impl From<AppThemeRaw> for AppTheme {
             link_invalid,
             socket,
             ext,
+            tabs: TabTheme::from(tabs),
         }
     }
 }
 
 #[derive(Clone, Debug)]
 pub struct AppTheme {
+    pub tabs: TabTheme,
     pub regular: AppStyle,
     pub selection: AppStyle,
     pub visual_mode_selection: AppStyle,
@@ -93,4 +114,10 @@ impl std::default::Default for AppTheme {
         // If it fails then there is a (syntax) error in the default config file
         Self::default_res().unwrap()
     }
+}
+
+#[derive(Clone, Debug)]
+pub struct TabTheme {
+    pub inactive: AppStyle,
+    pub active: AppStyle,
 }

--- a/src/config/theme/style.rs
+++ b/src/config/theme/style.rs
@@ -2,7 +2,7 @@ use colors_transform::{Color, Rgb};
 
 use serde_derive::Deserialize;
 
-use tui::style;
+use tui::style::{self, Style};
 
 const fn default_color() -> style::Color {
     style::Color::Reset
@@ -117,6 +117,10 @@ impl AppStyle {
         self.modifier.insert(modifier);
         self
     }
+
+    pub fn as_style(&self) -> Style {
+        Style::from(self)
+    }
 }
 
 impl std::default::Default for AppStyle {
@@ -126,5 +130,14 @@ impl std::default::Default for AppStyle {
             bg: default_color(),
             modifier: style::Modifier::empty(),
         }
+    }
+}
+
+impl From<&AppStyle> for Style {
+    fn from(style: &AppStyle) -> Self {
+        Self::default()
+            .fg(style.fg)
+            .bg(style.bg)
+            .add_modifier(style.modifier)
     }
 }

--- a/src/ui/widgets/tui_tab.rs
+++ b/src/ui/widgets/tui_tab.rs
@@ -2,11 +2,11 @@ use std::ffi::OsStr;
 
 use tui::buffer::Buffer;
 use tui::layout::Rect;
-use tui::style::{Color, Modifier, Style};
 use tui::text::{Line, Span};
 use tui::widgets::{Paragraph, Widget, Wrap};
 
 use crate::context::TabContext;
+use crate::THEME_T;
 
 pub struct TuiTabBar<'a> {
     context: &'a TabContext,
@@ -20,10 +20,8 @@ impl<'a> TuiTabBar<'a> {
 
 impl<'a> Widget for TuiTabBar<'a> {
     fn render(self, area: Rect, buf: &mut Buffer) {
-        let regular_style = Style::default().fg(Color::White);
-        let selected_style = Style::default()
-            .fg(Color::White)
-            .add_modifier(Modifier::REVERSED);
+        let regular_style = THEME_T.tabs.inactive.as_style();
+        let selected_style = THEME_T.tabs.active.as_style();
 
         let index = self.context.index;
         let tab_order = self.context.tab_order.as_slice();


### PR DESCRIPTION
Text style for tabs can be configured within
`theme.toml` with the dotted keys `tab.active` and `tab.inactive`.

The default style is the same as the former hard-coded style.

`theme.toml` has been restructured and comments have been added to give a short documentation on each style item.

The documentation (`theme.toml.md`) has been enhanced, and the excerpt of `theme.toml` with additional comments has been removed from there.

That way it should be easier for devs to keep docs and the default `theme.toml` in sync, and easier for users when the detail comments can be found in the configuration file itself.

The conversion from `AppStyle` to `tui::style::Style` is now provided as a function of `AppStyle` and a `From`-implementation for `Style` to avoid having the same factory code repeating all over.