### PR TITLE
refactor: avoid changing constraints during PreviewFileState load

### DIFF
--- a/src/ui/views/tui_folder_view.rs
+++ b/src/ui/views/tui_folder_view.rs
@@ -293,6 +293,7 @@ pub fn get_constraints(context: &AppContext) -> &[Constraint; 3] {
                     Some(PreviewFileState::Success { data }) if data.status.code() != Some(1) => {
                         &display_options.default_layout
                     }
+                    Some(PreviewFileState::Loading) => &display_options.default_layout,
                     _ => &display_options.no_preview_layout,
                 },
             },


### PR DESCRIPTION
File previews load pretty quickly. Adjusting constraints during loading state made the file sizes flicker on the right side of my screen due to the rapidly growing and shrinking center column. This change keeps the columns a consistent size when highlighting new items making the application a bit easier on the eyes.