### PR TITLE
Fix: remove an extra level of folder in topbar shorttened pathname

### DIFF
--- a/src/ui/widgets/tui_topbar.rs
+++ b/src/ui/widgets/tui_topbar.rs
@@ -46,6 +46,7 @@ impl<'a> Widget for TuiTopBar<'a> {
                         _ => {}
                     }
                 }
+                short_path.truncate(short_path.len() - 2);
                 ellipses = Some(Span::styled(short_path, path_style));
                 curr_path_str = s.to_string_lossy().into_owned();
             }


### PR DESCRIPTION
This pull request is a fix to the topbar current directory name display in the shorttened version.

The original behavior is somewhat comfusing that the last directory name is displayed twice, both the shorttened one character name and the full name.

eg. the working directory is `/home/ainevsia/test/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/bbbbbbbbbbbbbbbbbbb/cccccccccccccccccccccccccccccccccccc`

the top bar is displaying `/h/a/t/a/b/c/cccccccccccccccccccccccccccccccccccc`

which should be `/h/a/t/a/b/cccccccccccccccccccccccccccccccccccc`