### PR TITLE
Fix incorrect sort method field in example config 

### DIFF
--- a/config/joshuto.toml
+++ b/config/joshuto.toml
@@ -23,8 +23,8 @@ tilde_in_titlebar = true
 line_number_style = "none"
 
 [display.sort]
-# lexical, mtime, natural
-method = "natural"
+# lexical, mtime, natural, size, ext
+sort_method = "natural"
 case_sensitive = false
 directories_first = true
 reverse = false

--- a/docs/configuration/joshuto.toml.md
+++ b/docs/configuration/joshuto.toml.md
@@ -62,7 +62,9 @@ line_number_style = "none"
 # - lexical  (10.txt comes before 2.txt)
 # - natural  (2.txt comes before 10.txt)
 # - mtime
-method = "natural"
+# - size
+# - ext
+sort_method = "natural"
 
 # case sensitive sorting
 case_sensitive = false


### PR DESCRIPTION
When I follow the default config files in `/config/joshuto.toml`, I find the field [method](https://github.com/kamiyaa/joshuto/blob/6cb151ea4b58d006cfc52f54d52be05110bd5b90/config/joshuto.toml#L27C19-L27C19) which decides how to sort items doesn't work. It's because the default name of it in source code is [sort_method](https://github.com/kamiyaa/joshuto/blob/6cb151ea4b58d006cfc52f54d52be05110bd5b90/src/config/general/sort_raw.rs#L20C8-L20C8). 