### PR TITLE
feat: Add support for command aliases

### DIFF
--- a/docs/configuration/joshuto.toml.md
+++ b/docs/configuration/joshuto.toml.md
@@ -74,4 +74,9 @@ directories_first = true
 
 # sort in reverse
 reverse = false
+
+# Optional list of command aliases (empty by default)
+[cmd_aliases]
+# q = "quit"
+# ...
 ```

--- a/src/commands/command_line.rs
+++ b/src/commands/command_line.rs
@@ -23,8 +23,13 @@ pub fn read_and_execute(
         .get_input(backend, context, &mut listener);
 
     if let Some(s) = user_input {
-        let trimmed = s.trim_start();
+        let mut trimmed = s.trim_start();
         context.commandline_context_mut().history_mut().add(trimmed);
+
+        if let Some(alias) = context.config_ref().cmd_aliases.get(trimmed) {
+            trimmed = alias;
+        }
+
         let command = Command::from_str(trimmed)?;
         command.execute(context, backend, keymap_t)
     } else {

--- a/src/config/general/app.rs
+++ b/src/config/general/app.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use super::app_raw::AppConfigRaw;
 use super::DEFAULT_CONFIG_FILE_PATH;
 
@@ -10,6 +12,7 @@ pub struct AppConfig {
     pub xdg_open: bool,
     pub xdg_open_fork: bool,
     pub watch_files: bool,
+    pub cmd_aliases: HashMap<String, String>,
     pub _display_options: DisplayOption,
     pub _preview_options: PreviewOption,
     pub _tab_options: TabOption,

--- a/src/config/general/app_raw.rs
+++ b/src/config/general/app_raw.rs
@@ -1,5 +1,5 @@
-use std::convert::From;
 use std::collections::HashMap;
+use std::convert::From;
 
 use serde_derive::Deserialize;
 

--- a/src/config/general/app_raw.rs
+++ b/src/config/general/app_raw.rs
@@ -1,4 +1,5 @@
 use std::convert::From;
+use std::collections::HashMap;
 
 use serde_derive::Deserialize;
 
@@ -28,6 +29,8 @@ pub struct AppConfigRaw {
     pub xdg_open_fork: bool,
     #[serde(default = "default_true")]
     pub watch_files: bool,
+    #[serde(default)]
+    pub cmd_aliases: HashMap<String, String>,
     #[serde(default, rename = "display")]
     pub display_options: DisplayOptionRaw,
     #[serde(default, rename = "preview")]
@@ -43,6 +46,7 @@ impl From<AppConfigRaw> for AppConfig {
             xdg_open: raw.xdg_open,
             xdg_open_fork: raw.xdg_open_fork,
             watch_files: raw.watch_files,
+            cmd_aliases: raw.cmd_aliases,
             _display_options: DisplayOption::from(raw.display_options),
             _preview_options: PreviewOption::from(raw.preview_options),
             _tab_options: TabOption::from(raw.tab_options),


### PR DESCRIPTION
I think it can be handy to have the ability to set custom command aliases (such as `:q` aliased to `:quit`), so I added a really simple implementation with a `HashMap`, which works fine for this task. For configuration I chose to put it in the main `joshuto.toml` because it's optional and if specified, the list isn't likely to be really long.
Let me know if it's a welcome feature or if there's something you would do differently.