### PR TITLE
added all_selected field in CopyFilePath

### DIFF
--- a/config/keymap.toml
+++ b/config/keymap.toml
@@ -70,6 +70,7 @@ keymap = [
   { keys = ["y", "n"], command = "copy_filename" },
   { keys = ["y", "."], command = "copy_filename_without_extension" },
   { keys = ["y", "p"], command = "copy_filepath" },
+  { keys = ["y", "a"], command = "copy_filepath --all-selected=true" },
   { keys = ["y", "d"], command = "copy_dirpath" },
 
   { keys = ["p", "l"], command = "symlink_files --relative=false" },

--- a/src/commands/file_ops.rs
+++ b/src/commands/file_ops.rs
@@ -101,6 +101,26 @@ pub fn copy_filepath(context: &mut AppContext) -> JoshutoResult {
     Ok(())
 }
 
+pub fn copy_filepaths(context: &mut AppContext) -> JoshutoResult {
+    let selected = context
+        .tab_context_ref()
+        .curr_tab_ref()
+        .curr_list_ref()
+        .map(|c| c.get_selected_paths());
+    if let Some(selected) = selected {
+        let files = selected.into_iter().fold(String::new(), |mut acc, x| {
+            if let Some(s) = x.to_str() {
+                acc.push_str(s);
+                acc.push('\n')
+            }
+            acc
+        });
+        copy_string_to_buffer(files)?;
+    }
+
+    Ok(())
+}
+
 pub fn copy_dirpath(context: &mut AppContext) -> JoshutoResult {
     let opt_entry = context
         .tab_context_ref()

--- a/src/commands/file_ops.rs
+++ b/src/commands/file_ops.rs
@@ -86,38 +86,29 @@ pub fn copy_filename_without_extension(context: &mut AppContext) -> JoshutoResul
     Ok(())
 }
 
-pub fn copy_filepath(context: &mut AppContext) -> JoshutoResult {
-    let entry_file_path = context
-        .tab_context_ref()
-        .curr_tab_ref()
-        .curr_list_ref()
-        .and_then(|c| c.curr_entry_ref())
-        .and_then(|entry| entry.file_path().to_str())
-        .map(|s| s.to_string());
-
+pub fn copy_filepath(context: &mut AppContext, all: bool) -> JoshutoResult {
+    let selected = context.tab_context_ref().curr_tab_ref().curr_list_ref();
+    let entry_file_path = {
+        if all {
+            selected.map(|c| c.get_selected_paths()).and_then(|sel| {
+                sel.into_iter().try_fold(String::new(), |mut acc, x| {
+                    if let Some(s) = x.to_str() {
+                        acc.push_str(s);
+                        acc.push('\n');
+                    }
+                    Some(acc)
+                })
+            })
+        } else {
+            selected
+                .and_then(|c| c.curr_entry_ref())
+                .and_then(|entry| entry.file_path().to_str())
+                .map(|s| s.to_string())
+        }
+    };
     if let Some(file_path) = entry_file_path {
         copy_string_to_buffer(file_path)?;
     }
-    Ok(())
-}
-
-pub fn copy_filepaths(context: &mut AppContext) -> JoshutoResult {
-    let selected = context
-        .tab_context_ref()
-        .curr_tab_ref()
-        .curr_list_ref()
-        .map(|c| c.get_selected_paths());
-    if let Some(selected) = selected {
-        let files = selected.into_iter().fold(String::new(), |mut acc, x| {
-            if let Some(s) = x.to_str() {
-                acc.push_str(s);
-                acc.push('\n')
-            }
-            acc
-        });
-        copy_string_to_buffer(files)?;
-    }
-
     Ok(())
 }
 

--- a/src/key_command/command.rs
+++ b/src/key_command/command.rs
@@ -26,7 +26,9 @@ pub enum Command {
     CopyFiles,
     CopyFileName,
     CopyFileNameWithoutExtension,
-    CopyFilePath,
+    CopyFilePath {
+        all_selected: bool,
+    },
     CopyDirPath,
     SymlinkFiles {
         relative: bool,

--- a/src/key_command/impl_appcommand.rs
+++ b/src/key_command/impl_appcommand.rs
@@ -25,7 +25,7 @@ impl AppCommand for Command {
             Self::CopyFiles => CMD_COPY_FILES,
             Self::CopyFileName => CMD_COPY_FILENAME,
             Self::CopyFileNameWithoutExtension => CMD_COPY_FILENAME_WITHOUT_EXTENSION,
-            Self::CopyFilePath => CMD_COPY_FILEPATH,
+            Self::CopyFilePath { .. } => CMD_COPY_FILEPATH,
             Self::CopyDirPath => CMD_COPY_DIRECTORY_PATH,
             Self::SymlinkFiles { .. } => CMD_SYMLINK_FILES,
             Self::PasteFiles { .. } => CMD_PASTE_FILES,

--- a/src/key_command/impl_appexecute.rs
+++ b/src/key_command/impl_appexecute.rs
@@ -41,7 +41,12 @@ impl AppExecute for Command {
             Self::CopyFileNameWithoutExtension => {
                 file_ops::copy_filename_without_extension(context)
             }
-            Self::CopyFilePath => file_ops::copy_filepath(context),
+            Self::CopyFilePath {
+                all_selected: false,
+            } => file_ops::copy_filepath(context),
+            Self::CopyFilePath {
+                all_selected: true,
+            } => file_ops::copy_filepaths(context),
             Self::CopyDirPath => file_ops::copy_dirpath(context),
             Self::SymlinkFiles { relative: true } => file_ops::symlink_relative(context),
             Self::SymlinkFiles { relative: false } => file_ops::symlink_absolute(context),

--- a/src/key_command/impl_appexecute.rs
+++ b/src/key_command/impl_appexecute.rs
@@ -43,10 +43,8 @@ impl AppExecute for Command {
             }
             Self::CopyFilePath {
                 all_selected: false,
-            } => file_ops::copy_filepath(context),
-            Self::CopyFilePath {
-                all_selected: true,
-            } => file_ops::copy_filepaths(context),
+            } => file_ops::copy_filepath(context, false),
+            Self::CopyFilePath { all_selected: true } => file_ops::copy_filepath(context, true),
             Self::CopyDirPath => file_ops::copy_dirpath(context),
             Self::SymlinkFiles { relative: true } => file_ops::symlink_relative(context),
             Self::SymlinkFiles { relative: false } => file_ops::symlink_absolute(context),

--- a/src/key_command/impl_comment.rs
+++ b/src/key_command/impl_comment.rs
@@ -40,7 +40,8 @@ impl CommandComment for Command {
             Self::CopyFiles => "Copy selected files",
             Self::CopyFileName => "Copy filename",
             Self::CopyFileNameWithoutExtension => "Copy filename without extension",
-            Self::CopyFilePath => "Copy path to file",
+            Self::CopyFilePath { all_selected: true } => "Copy all selected paths to file",
+            Self::CopyFilePath { .. } => "Copy path to file",
             Self::CopyDirPath => "Copy directory name",
             Self::SymlinkFiles { .. } => "Symlink selected files",
 

--- a/src/key_command/impl_from_str.rs
+++ b/src/key_command/impl_from_str.rs
@@ -72,7 +72,7 @@ impl std::str::FromStr for Command {
             CMD_COPY_FILENAME_WITHOUT_EXTENSION,
             Self::CopyFileNameWithoutExtension
         );
-        simple_command_conversion_case!(command, CMD_COPY_FILEPATH, Self::CopyFilePath);
+        // simple_command_conversion_case!(command, CMD_COPY_FILEPATH, Self::CopyFilePath);
         simple_command_conversion_case!(command, CMD_COPY_DIRECTORY_PATH, Self::CopyDirPath);
 
         simple_command_conversion_case!(command, CMD_OPEN_FILE, Self::OpenFile);
@@ -228,6 +228,21 @@ impl std::str::FromStr for Command {
                 }
             }
             Ok(Self::SymlinkFiles { relative })
+        } else if command == CMD_COPY_FILEPATH {
+            let mut all_selected = false;
+            for arg in arg.split_whitespace() {
+                match arg {
+                    "--all-selected=true" => all_selected = true,
+                    "" => all_selected = false,
+                    _ => {
+                        return Err(JoshutoError::new(
+                            JoshutoErrorKind::UnrecognizedArgument,
+                            format!("{}: unknown option '{}'", command, arg),
+                        ));
+                    }
+                }
+            }
+            Ok(Self::CopyFilePath { all_selected })
         } else if command == CMD_PASTE_FILES {
             let mut options = FileOperationOptions::default();
             for arg in arg.split_whitespace() {


### PR DESCRIPTION
`copy_filepath` command can now have `--all-selected` field for copying file paths for currently selected files.