### PR TITLE
feat: add `noconfirm` option to `delete_files` command

### DIFF
--- a/docs/configuration/keymap.toml.md
+++ b/docs/configuration/keymap.toml.md
@@ -269,6 +269,8 @@ function joshuto() {
 
 - `--foreground=true`: will delete files in the foreground
 - `--permanently`: force permanent deletion regardless of `use_trash` value.
+- `--noconfirm`: files will be deleted without asking for confirmation
+  (can be dangerous when `use_trash` is `false`)
 - will **_permanently_** delete files if `use_trash` is `false` in
   [joshuto.toml](https://github.com/kamiyaa/joshuto)/wiki/Configuration#joshutotoml)
 - if `use_trash` is `true`, `joshuto` will try to use

--- a/src/commands/delete_files.rs
+++ b/src/commands/delete_files.rs
@@ -10,27 +10,7 @@ use crate::io::{FileOperation, FileOperationOptions, IoWorkerThread};
 use crate::ui::widgets::TuiPrompt;
 use crate::ui::AppBackend;
 
-fn delete_files(
-    context: &mut AppContext,
-    backend: &mut AppBackend,
-    background: bool,
-    permanently: bool,
-) -> JoshutoResult<()> {
-    let paths = context
-        .tab_context_ref()
-        .curr_tab_ref()
-        .curr_list_ref()
-        .map(|s| s.get_selected_paths())
-        .unwrap_or_default();
-    let paths_len = paths.len();
-    if paths_len == 0 {
-        let err = JoshutoError::new(
-            JoshutoErrorKind::InvalidParameters,
-            "no files selected".to_string(),
-        );
-        return Err(err);
-    }
-
+fn prompt(context: &mut AppContext, backend: &mut AppBackend, paths_len: usize) -> bool {
     let ch = {
         let prompt_str = format!("Delete {} files? (Y/n)", paths_len);
         let mut prompt = TuiPrompt::new(&prompt_str);
@@ -39,7 +19,7 @@ fn delete_files(
 
     match ch {
         Key::Char('Y') | Key::Char('y') | Key::Char('\n') => {
-            let confirm_delete = if paths_len > 1 {
+            if paths_len > 1 {
                 // prompt user again for deleting multiple files
                 let ch = {
                     let prompt_str = "Are you sure? (y/N)";
@@ -49,33 +29,40 @@ fn delete_files(
                 ch == Key::Char('y')
             } else {
                 true
-            };
-            if confirm_delete {
-                let file_op = FileOperation::Delete;
-                let options = FileOperationOptions {
-                    overwrite: false,
-                    skip_exist: false,
-                    permanently: !context.config_ref().use_trash || permanently,
-                };
-
-                let dest = path::PathBuf::new();
-                let worker_thread = IoWorkerThread::new(file_op, paths.clone(), dest, options);
-                if background {
-                    context.worker_context_mut().push_worker(worker_thread);
-                } else {
-                    let (wtx, _) = mpsc::channel();
-                    worker_thread.start(wtx)?;
-                }
-
-                let history = context.tab_context_mut().curr_tab_mut().history_mut();
-                for path in paths.iter().filter(|p| p.is_dir()) {
-                    history.remove(path);
-                }
             }
-            Ok(())
         }
-        _ => Ok(()),
+        _ => false,
     }
+}
+
+fn delete_files(
+    context: &mut AppContext,
+    paths: Vec<path::PathBuf>,
+    background: bool,
+    permanently: bool,
+) -> JoshutoResult<()> {
+    let file_op = FileOperation::Delete;
+    let options = FileOperationOptions {
+        overwrite: false,
+        skip_exist: false,
+        permanently: !context.config_ref().use_trash || permanently,
+    };
+
+    let dest = path::PathBuf::new();
+    let worker_thread = IoWorkerThread::new(file_op, paths.clone(), dest, options);
+    if background {
+        context.worker_context_mut().push_worker(worker_thread);
+    } else {
+        let (wtx, _) = mpsc::channel();
+        worker_thread.start(wtx)?;
+    }
+
+    let history = context.tab_context_mut().curr_tab_mut().history_mut();
+    for path in paths.iter().filter(|p| p.is_dir()) {
+        history.remove(path);
+    }
+
+    Ok(())
 }
 
 pub fn delete_selected_files(
@@ -83,8 +70,27 @@ pub fn delete_selected_files(
     backend: &mut AppBackend,
     background: bool,
     permanently: bool,
+    noconfirm: bool,
 ) -> JoshutoResult {
-    delete_files(context, backend, background, permanently)?;
+    let paths = context
+        .tab_context_ref()
+        .curr_tab_ref()
+        .curr_list_ref()
+        .map(|s| s.get_selected_paths())
+        .unwrap_or_default();
+
+    let paths_len = paths.len();
+    if paths_len == 0 {
+        let err = JoshutoError::new(
+            JoshutoErrorKind::InvalidParameters,
+            "no files selected".to_string(),
+        );
+        return Err(err);
+    }
+
+    if noconfirm || prompt(context, backend, paths_len) {
+        delete_files(context, paths, background, permanently)?;
+    }
 
     let curr_tab = context.tab_context_ref().curr_tab_ref();
     let options = context.config_ref().display_options_ref().clone();

--- a/src/key_command/command.rs
+++ b/src/key_command/command.rs
@@ -42,6 +42,7 @@ pub enum Command {
     DeleteFiles {
         background: bool,
         permanently: bool,
+        noconfirm: bool,
     },
 
     CursorMoveUp {

--- a/src/key_command/impl_appexecute.rs
+++ b/src/key_command/impl_appexecute.rs
@@ -53,7 +53,14 @@ impl AppExecute for Command {
             Self::DeleteFiles {
                 background,
                 permanently,
-            } => delete_files::delete_selected_files(context, backend, *background, *permanently),
+                noconfirm,
+            } => delete_files::delete_selected_files(
+                context,
+                backend,
+                *background,
+                *permanently,
+                *noconfirm,
+            ),
 
             Self::CursorMoveUp { offset } => cursor_move::up(context, *offset),
             Self::CursorMoveDown { offset } => cursor_move::down(context, *offset),

--- a/src/key_command/impl_display.rs
+++ b/src/key_command/impl_display.rs
@@ -27,17 +27,19 @@ impl std::fmt::Display for Command {
             Self::DeleteFiles {
                 background,
                 permanently,
+                noconfirm,
             } => {
                 write!(
                     f,
-                    "{}{}{}",
+                    "{}{}{}{}",
                     self.command(),
                     if !background {
                         " --foreground=true"
                     } else {
                         ""
                     },
-                    if *permanently { " --permanently" } else { "" }
+                    if *permanently { " --permanently" } else { "" },
+                    if *noconfirm { " --noconfirm" } else { "" },
                 )
             }
 

--- a/src/key_command/impl_from_str.rs
+++ b/src/key_command/impl_from_str.rs
@@ -263,12 +263,13 @@ impl std::str::FromStr for Command {
             }
             Ok(Self::PasteFiles { options })
         } else if command == CMD_DELETE_FILES {
-            let (mut permanently, mut background) = (false, false);
+            let [mut permanently, mut background, mut noconfirm] = [false; 3];
             for arg in arg.split_whitespace() {
                 match arg {
                     "--background=true" => background = true,
                     "--background=false" => background = false,
                     "--permanently" => permanently = true,
+                    "--noconfirm" => noconfirm = true,
                     _ => {
                         return Err(JoshutoError::new(
                             JoshutoErrorKind::UnrecognizedArgument,
@@ -280,6 +281,7 @@ impl std::str::FromStr for Command {
             Ok(Self::DeleteFiles {
                 background,
                 permanently,
+                noconfirm,
             })
         } else if command == CMD_RENAME_FILE {
             match arg {


### PR DESCRIPTION
Sometimes having to confirm every file deletion can be annoying, especially if `use_trash` is enabled, so I added this option to skip the prompt.
In `commands/delete_files.rs` I moved the prompt part in a separate function so that it's easier to skip, and left in the `delete_files` function only the part that actually deletes the files.