### PR TITLE
Fix: macos build on automated-build

### DIFF
--- a/.github/workflows/automated-build.yml
+++ b/.github/workflows/automated-build.yml
@@ -20,7 +20,7 @@ jobs:
           - {os: ubuntu-20.04, target: aarch64-unknown-linux-gnu, use-cross: true}
           - {os: ubuntu-20.04, target: x86_64-unknown-linux-gnu}
           - {os: ubuntu-20.04, target: x86_64-unknown-linux-musl, use-cross: true}
-          - {os: macos-10.15, target: x86_64-apple-darwin}
+          - {os: macos-13, target: x86_64-apple-darwin}
     steps:
       - name: Checkout source code
         uses: actions/checkout@v2

--- a/.github/workflows/automated-build.yml
+++ b/.github/workflows/automated-build.yml
@@ -129,7 +129,7 @@ jobs:
         id: is-release
         shell: bash
         run: |
-          unset IS_RELEASE ; if [[ $GITHUB_REF =~ ^releases/tags/v[0-9].* ]]; then IS_RELEASE='true' ; fi
+          unset IS_RELEASE ; if [[ $GITHUB_REF =~ ^refs/tags/v[0-9].* ]]; then IS_RELEASE='true' ; fi
           echo ::set-output name=IS_RELEASE::${IS_RELEASE}
       - name: Publish archives and packages
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/automated-build.yml
+++ b/.github/workflows/automated-build.yml
@@ -129,7 +129,7 @@ jobs:
         id: is-release
         shell: bash
         run: |
-          unset IS_RELEASE ; if [[ $GITHUB_REF =~ ^refs/tags/v[0-9].* ]]; then IS_RELEASE='true' ; fi
+          unset IS_RELEASE ; if [[ $GITHUB_REF =~ ^releases/tags/v[0-9].* ]]; then IS_RELEASE='true' ; fi
           echo ::set-output name=IS_RELEASE::${IS_RELEASE}
       - name: Publish archives and packages
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
This PR addresses the macOS build failure in the automated build process. The issue was caused by [deprecated](https://github.blog/changelog/2022-07-20-github-actions-the-macos-10-15-actions-runner-image-is-being-deprecated-and-will-be-removed-by-8-30-22/) versions.

After merging this pull request, note that the macOS binary could be attached to the current release by [re-running all jobs](https://docs.github.com/en/actions/managing-workflow-runs/re-running-workflows-and-jobs) or the failed one.