### PR TITLE
docs: add preview section to joshuto.yml example

### DIFF
--- a/docs/configuration/joshuto.toml.md
+++ b/docs/configuration/joshuto.toml.md
@@ -85,6 +85,15 @@ directories_first = true
 # sort in reverse
 reverse = false
 
+# Configurations related to preview
+[preview]
+
+# Maximum preview file size in bytes
+max_preview_size = 2097152
+
+# Executable script for previews
+preview_script = "~/.config/joshuto/preview_file.sh"
+
 # Configurations related to searching and selecting files
 [search]
 # Different case sensitivities for operations using substring matching


### PR DESCRIPTION
Add preview section to joshuto.yml example configuration as it is defined in the default configuration. Using the example joshuto.yml as the base for custom configuration broke the preview functionality.