### PR TITLE
feat: wezterm cwd compatibility

### DIFF
--- a/src/commands/change_directory.rs
+++ b/src/commands/change_directory.rs
@@ -4,10 +4,11 @@ use crate::commands::reload;
 use crate::context::AppContext;
 use crate::error::AppResult;
 use crate::history::DirectoryHistory;
+use crate::util::cwd;
 
 // ChangeDirectory command
 pub fn cd(path: &path::Path, context: &mut AppContext) -> std::io::Result<()> {
-    std::env::set_current_dir(path)?;
+    cwd::set_current_dir(path)?;
     context.tab_context_mut().curr_tab_mut().set_cwd(path);
     Ok(())
 }
@@ -51,7 +52,7 @@ pub fn parent_directory(context: &mut AppContext) -> AppResult {
         .parent()
         .map(|p| p.to_path_buf())
     {
-        std::env::set_current_dir(&parent)?;
+        cwd::set_current_dir(&parent)?;
         context
             .tab_context_mut()
             .curr_tab_mut()
@@ -65,7 +66,7 @@ pub fn parent_directory(context: &mut AppContext) -> AppResult {
 pub fn previous_directory(context: &mut AppContext) -> AppResult {
     if let Some(path) = context.tab_context_ref().curr_tab_ref().previous_dir() {
         let path = path.to_path_buf();
-        std::env::set_current_dir(&path)?;
+        cwd::set_current_dir(&path)?;
         context
             .tab_context_mut()
             .curr_tab_mut()

--- a/src/commands/tab_ops.rs
+++ b/src/commands/tab_ops.rs
@@ -7,7 +7,7 @@ use crate::context::AppContext;
 use crate::error::{AppError, AppErrorKind, AppResult};
 use crate::history::DirectoryHistory;
 use crate::tab::{JoshutoTab, TabHomePage};
-use crate::util::unix;
+use crate::util::{cwd, unix};
 
 use crate::HOME_DIR;
 
@@ -16,7 +16,7 @@ use super::quit::{quit_with_action, QuitAction};
 fn _tab_switch(new_index: usize, context: &mut AppContext) -> std::io::Result<()> {
     context.tab_context_mut().index = new_index;
     let cwd = context.tab_context_ref().curr_tab_ref().cwd().to_path_buf();
-    std::env::set_current_dir(cwd.as_path())?;
+    cwd::set_current_dir(cwd.as_path())?;
 
     let entry_path = match context
         .tab_context_ref()

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,6 +31,7 @@ use config::clean::bookmarks::Bookmarks;
 use config::clean::mimetype::AppProgramRegistry;
 use config::clean::theme::AppTheme;
 use config::TomlConfigFile;
+use util::cwd;
 
 use crate::commands::quit::QuitAction;
 
@@ -143,7 +144,7 @@ fn run_main(args: Args) -> Result<i32, AppError> {
     }
 
     if let Some(path) = args.rest.first() {
-        if let Err(err) = std::env::set_current_dir(path) {
+        if let Err(err) = cwd::set_current_dir(path) {
             eprintln!("{err}");
             process::exit(1);
         }

--- a/src/tab/tab_struct.rs
+++ b/src/tab/tab_struct.rs
@@ -9,6 +9,7 @@ use crate::context::UiContext;
 use crate::fs::JoshutoDirList;
 use crate::history::{DirectoryHistory, JoshutoHistory};
 use crate::preview::preview_dir::PreviewDirState;
+// use crate::HOSTNAME;
 
 type HistoryMetadata = HashMap<path::PathBuf, PreviewDirState>;
 
@@ -56,6 +57,9 @@ impl JoshutoTab {
     pub fn set_cwd(&mut self, cwd: &path::Path) {
         self._previous_dir = Some(self._cwd.to_path_buf());
         self._cwd = cwd.to_path_buf();
+
+        // OSC 7: Escape sequence to set the working directory
+        // print!("\x1b]7;file://{}{}\x1b\\", HOSTNAME.as_str(), cwd.display());
     }
 
     pub fn previous_dir(&self) -> Option<&path::Path> {

--- a/src/util/cwd.rs
+++ b/src/util/cwd.rs
@@ -1,0 +1,15 @@
+use std::path;
+
+use crate::HOSTNAME;
+
+pub fn set_current_dir(path: &path::Path) -> std::io::Result<()> {
+    std::env::set_current_dir(path)?;
+    // OSC 7:
+    // Escape sequences to advise the terminal of the working directory
+    print!(
+        "\x1b]7;file://{}{}\x1b\\",
+        HOSTNAME.as_str(),
+        path.display()
+    );
+    Ok(())
+}

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,3 +1,4 @@
+pub mod cwd;
 pub mod format;
 pub mod fs;
 pub mod keyparse;


### PR DESCRIPTION
This PR makes joshuto compatible with [wezterm](https://wezfurlong.org/wezterm/) at least with the way it manages the current directory updates.

1. Added a new `cwd` utility module.
2. Centralized CWD updates using the `cwd::set_current_dir` function.
3. Updated to use the `cwd` utility for CWD management.
4. Implements OSC 7: Escape sequences to inform the terminal about the current directory [ref](https://wezfurlong.org/wezterm/shell-integration.html#osc-7-escape-sequence-to-set-the-working-directory).