### PR TITLE
fix: remove the debug info causing the chaos in UI

### DIFF
--- a/src/ui/tab_list_builder.rs
+++ b/src/ui/tab_list_builder.rs
@@ -40,7 +40,7 @@ impl TabLabel {
             let home_dir_str = home_dir.to_string_lossy().into_owned();
             full_path_str = full_path_str.replace(&home_dir_str, "~");
         }
-        eprintln!("full_path_str: {:?}", full_path_str);
+        // eprintln!("full_path_str: {:?}", full_path_str);
         let last = Path::new(&full_path_str)
             .file_name()
             .unwrap_or_default()


### PR DESCRIPTION
the redundent `eprintln` could cause UI unusable, so I comment it.