### PR TITLE
Enable large file support for exiftool

### DIFF
--- a/config/preview_file.sh
+++ b/config/preview_file.sh
@@ -41,6 +41,10 @@ IFS=$'\n'
 # * pipefail causes a pipeline to fail also if a command other than the last one fails
 set -o noclobber -o noglob -o nounset -o pipefail
 
+# Enable exiftool large file support
+shopt -s expand_aliases
+alias exiftool='exiftool -api largefilesupport=1'
+
 FILE_PATH=""
 PREVIEW_WIDTH=10
 PREVIEW_HEIGHT=10


### PR DESCRIPTION
Allows for previewing of whole file metadata even on large files. If there's any kind of concern regarding parsing large files, there's the `max_preview_size` anyway that can be set in `joshuto.toml`