### PR TITLE
Fixed syntax errors for scripts provided in docs/image_previews/kitty.md

### DIFF
--- a/docs/image_previews/kitty.md
+++ b/docs/image_previews/kitty.md
@@ -39,7 +39,6 @@ case "$mimetype" in
 	image/*)
 		image "${FILE_PATH}"
 		;;
-	*)
 	video/*)
 		video "${FILE_PATH}"
 		;;


### PR DESCRIPTION
I want to use kitty for image preview, so I use the script provided in `docs/image_previews/kitty.md`. 
I found that the script reported an syntax error.
![image](https://github.com/11D-Beyonder/joshuto/assets/58369870/39036f41-0b66-4ef0-a599-cf49764a8f81)
I fixed a syntax error in the image so that the image preview and video thumbnail preview function properly.
![image](https://github.com/kamiyaa/joshuto/assets/58369870/2ecd29ee-b7c5-419e-be8c-84903871ca4c)
