### PR TITLE
feat lscolors support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -632,6 +632,7 @@ dependencies = [
  "globset",
  "lazy_static",
  "libc",
+ "lscolors",
  "nix 0.27.1",
  "notify",
  "open",
@@ -764,6 +765,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lscolors"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53304fff6ab1e597661eee37e42ea8c47a146fca280af902bb76bff8a896e523"
+dependencies = [
+ "nu-ansi-term",
+]
+
+[[package]]
 name = "memchr"
 version = "2.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -844,6 +854,15 @@ dependencies = [
  "log",
  "mio",
  "walkdir",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd2800e1520bdc966782168a627aa5d1ad92e33b984bf7c7615d31280c83ff14"
+dependencies = [
  "windows-sys 0.48.0",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ filetime = "^0"
 globset = "^0"
 lazy_static = "^1"
 libc = "^0"
+lscolors = { version = "0.17.0", features = ["nu-ansi-term"] }
 notify = "^6"
 open = "^5"
 phf = { version = "^0", features = ["macros"], optional = true }

--- a/src/config/clean/theme/config.rs
+++ b/src/config/clean/theme/config.rs
@@ -21,7 +21,7 @@ pub struct AppTheme {
     pub link_invalid: AppStyle,
     pub socket: AppStyle,
     pub ext: HashMap<String, AppStyle>,
-    pub lscolors: Option<LsColors>
+    pub lscolors: Option<LsColors>,
 }
 
 impl AppTheme {
@@ -64,16 +64,13 @@ impl From<AppThemeRaw> for AppTheme {
                 (k.clone(), style)
             })
             .collect();
-        let lscolors =
-            if raw.lscolors_enabled {
-                let lscolors = LsColors::from_env();
-                let default = Some(
-                    LsColors::default()
-                );
-                lscolors.or(default)
-            } else {
-                None
-            };
+        let lscolors = if raw.lscolors_enabled {
+            let lscolors = LsColors::from_env();
+            let default = Some(LsColors::default());
+            lscolors.or(default)
+        } else {
+            None
+        };
 
         Self {
             selection,
@@ -86,7 +83,7 @@ impl From<AppThemeRaw> for AppTheme {
             socket,
             ext,
             tabs: TabTheme::from(tabs),
-            lscolors
+            lscolors,
         }
     }
 }

--- a/src/config/clean/theme/config.rs
+++ b/src/config/clean/theme/config.rs
@@ -1,3 +1,4 @@
+use lscolors::LsColors;
 use std::collections::HashMap;
 
 use crate::config::raw::theme::AppThemeRaw;
@@ -20,6 +21,7 @@ pub struct AppTheme {
     pub link_invalid: AppStyle,
     pub socket: AppStyle,
     pub ext: HashMap<String, AppStyle>,
+    pub lscolors: Option<LsColors>
 }
 
 impl AppTheme {
@@ -62,6 +64,16 @@ impl From<AppThemeRaw> for AppTheme {
                 (k.clone(), style)
             })
             .collect();
+        let lscolors =
+            if raw.lscolors_enabled {
+                let lscolors = LsColors::from_env();
+                let default = Some(
+                    LsColors::default()
+                );
+                lscolors.or(default)
+            } else {
+                None
+            };
 
         Self {
             selection,
@@ -74,6 +86,7 @@ impl From<AppThemeRaw> for AppTheme {
             socket,
             ext,
             tabs: TabTheme::from(tabs),
+            lscolors
         }
     }
 }

--- a/src/config/raw/theme/config.rs
+++ b/src/config/raw/theme/config.rs
@@ -26,4 +26,6 @@ pub struct AppThemeRaw {
     pub socket: AppStyleRaw,
     #[serde(default)]
     pub ext: HashMap<String, AppStyleRaw>,
+    #[serde(default)]
+    pub lscolors_enabled: bool
 }

--- a/src/config/raw/theme/config.rs
+++ b/src/config/raw/theme/config.rs
@@ -27,5 +27,5 @@ pub struct AppThemeRaw {
     #[serde(default)]
     pub ext: HashMap<String, AppStyleRaw>,
     #[serde(default)]
-    pub lscolors_enabled: bool
+    pub lscolors_enabled: bool,
 }

--- a/src/util/style.rs
+++ b/src/util/style.rs
@@ -1,4 +1,7 @@
+use ansi_to_tui::IntoText;
+use lscolors::LsColors;
 use ratatui::style::Style;
+use std::path::Path;
 
 use crate::fs::{FileType, JoshutoDirEntry, LinkType};
 use crate::util::unix;
@@ -23,6 +26,13 @@ impl PathStyleIfSome for Style {
 }
 
 pub fn entry_style(entry: &JoshutoDirEntry) -> Style {
+    match &THEME_T.lscolors {
+        Some(lscolors) => entry_lscolors_style(&lscolors, entry),
+        None => entry_theme_style(entry)
+    }
+}
+
+fn entry_theme_style(entry: &JoshutoDirEntry) -> Style {
     let metadata = &entry.metadata;
     let filetype = &metadata.file_type();
     let linktype = &metadata.link_type();
@@ -83,4 +93,34 @@ fn file_style(entry: &JoshutoDirEntry) -> Style {
             })
             .unwrap_or(regular_style)
     }
+}
+
+fn entry_lscolors_style(lscolors: &LsColors, entry: &JoshutoDirEntry) -> Style {
+    let path = &entry.file_path();
+    let default = Style::default();
+    lscolors_style(lscolors, path)
+        .unwrap_or(default)
+}
+
+fn lscolors_style(lscolors: &LsColors, path: &Path) -> Option<Style> {
+    let nu_ansi_term_style = lscolors
+        .style_for_path(path)?
+        .to_nu_ansi_term_style();
+    // Paths that are not valid UTF-8 are not styled by LS_COLORS.
+    let str = path
+        .to_str()?;
+    let text = nu_ansi_term_style
+        .paint(str)
+        .to_string()
+        .into_bytes()
+        .into_text()
+        .ok()?;
+    // Extract the first Style from the returned Text.
+    let style = text
+        .lines
+        .first()?
+        .spans
+        .first()?
+        .style;
+    Some(style)
 }

--- a/src/util/style.rs
+++ b/src/util/style.rs
@@ -27,8 +27,8 @@ impl PathStyleIfSome for Style {
 
 pub fn entry_style(entry: &JoshutoDirEntry) -> Style {
     match &THEME_T.lscolors {
-        Some(lscolors) => entry_lscolors_style(&lscolors, entry),
-        None => entry_theme_style(entry)
+        Some(lscolors) => entry_lscolors_style(lscolors, entry),
+        None => entry_theme_style(entry),
     }
 }
 
@@ -98,17 +98,13 @@ fn file_style(entry: &JoshutoDirEntry) -> Style {
 fn entry_lscolors_style(lscolors: &LsColors, entry: &JoshutoDirEntry) -> Style {
     let path = &entry.file_path();
     let default = Style::default();
-    lscolors_style(lscolors, path)
-        .unwrap_or(default)
+    lscolors_style(lscolors, path).unwrap_or(default)
 }
 
 fn lscolors_style(lscolors: &LsColors, path: &Path) -> Option<Style> {
-    let nu_ansi_term_style = lscolors
-        .style_for_path(path)?
-        .to_nu_ansi_term_style();
+    let nu_ansi_term_style = lscolors.style_for_path(path)?.to_nu_ansi_term_style();
     // Paths that are not valid UTF-8 are not styled by LS_COLORS.
-    let str = path
-        .to_str()?;
+    let str = path.to_str()?;
     let text = nu_ansi_term_style
         .paint(str)
         .to_string()
@@ -116,11 +112,6 @@ fn lscolors_style(lscolors: &LsColors, path: &Path) -> Option<Style> {
         .into_text()
         .ok()?;
     // Extract the first Style from the returned Text.
-    let style = text
-        .lines
-        .first()?
-        .spans
-        .first()?
-        .style;
+    let style = text.lines.first()?.spans.first()?.style;
     Some(style)
 }


### PR DESCRIPTION
# support `LS_COLORS`

This adds support for styling entries using the `LS_COLORS` environment variable. This styling is gated behind a configuration variable. If it's enabled, any other styling for entries based on theme configuration is ignored.

An example configuration line looks like

```toml
lscolors_enabled = true
```

in `theme.toml`.

This change adds a dependency on the [`lscolors`][0] crate. It addresses issue https://github.com/kamiyaa/joshuto/issues/443.

## verification

I verified these changes by running

```bash
nix develop --impure
, run
```

on my local machine.

```bash
uname -a
```
```
Linux berrio 6.1.72 #1-NixOS SMP PREEMPT_DYNAMIC Wed Jan 10 16:10:37 UTC 2024 x86_64 GNU/Linux
```

Here's an image of when `lscolors_enabled = true` in `theme.toml`.

![lscolors-enabled-true][1]

Here's an image of when `lscolors_enabled = false` in `theme.toml`.

![lscolors-enabled-false][2]

I also confirmed that

- when `lscolors_enabled` is not set in the configuration at all, `joshuto` behaves as if it is `false`
- older versions of `joshuto` ignore `lscolors_enabled` if it exists in the `theme.toml` file

[0]: https://github.com/sharkdp/lscolors
[1]: https://github.com/kamiyaa/joshuto/assets/7118777/e8241a6a-4462-4c72-b180-df61617ab904
[2]: https://github.com/kamiyaa/joshuto/assets/7118777/4f83550a-6599-443e-9c47-8c317b203ea1