### PR TITLE
fix: update all lists viewports on sort method change

### DIFF
--- a/src/commands/sort.rs
+++ b/src/commands/sort.rs
@@ -25,5 +25,22 @@ pub fn toggle_reverse(context: &mut AppContext) -> AppResult {
 
 fn refresh(context: &mut AppContext) -> AppResult {
     reload::soft_reload_curr_tab(context)?;
+
+    let ui_context = context.ui_context_ref().clone();
+    let display_options = context.config_ref().display_options_ref().clone();
+    let curr_tab = context.tab_context_mut().curr_tab_mut();
+
+    macro_rules! update_viewport {
+        ($x_list_mut: ident) => {
+            if let Some(list) = curr_tab.$x_list_mut() {
+                list.update_viewport(&ui_context, &display_options);
+            }
+        };
+    }
+
+    update_viewport!(curr_list_mut);
+    update_viewport!(parent_list_mut);
+    update_viewport!(child_list_mut);
+
     Ok(())
 }

--- a/src/fs/dirlist.rs
+++ b/src/fs/dirlist.rs
@@ -135,7 +135,7 @@ impl JoshutoDirList {
         }
     }
 
-    fn update_viewport(&mut self, ui_context: &UiContext, options: &DisplayOption) {
+    pub fn update_viewport(&mut self, ui_context: &UiContext, options: &DisplayOption) {
         if let Some(ix) = self.index {
             let height = ui_context.layout[0].height as usize;
 


### PR DESCRIPTION
I noticed that changing sort method in directories with many entries might not keep focus on the focused file (and the same goes for parent and child dirs). This patch fixes the issue.