### PR TITLE
feat: use semaphores instead of mutex locks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -490,6 +490,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
+name = "hermit-abi"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd5256b483761cd23699d0da46cc6fd2ee3be420bbe6d020ae4a091e70b7e9fd"
+
+[[package]]
 name = "home"
 version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -635,6 +641,7 @@ dependencies = [
  "lscolors",
  "nix 0.27.1",
  "notify",
+ "num_cpus",
  "open",
  "phf",
  "rand",
@@ -873,6 +880,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ lazy_static = "^1"
 libc = "^0"
 lscolors = { version = "0.17.0", features = ["nu-ansi-term"] }
 notify = "^6"
+num_cpus = "^1"
 open = "^5"
 phf = { version = "^0", features = ["macros"], optional = true }
 rand = "^0"

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -5,6 +5,7 @@ pub mod keyparse;
 pub mod mimetype;
 pub mod name_resolution;
 pub mod process;
+pub mod semaphore;
 pub mod string;
 pub mod style;
 pub mod unix;

--- a/src/util/semaphore.rs
+++ b/src/util/semaphore.rs
@@ -1,0 +1,47 @@
+use std::sync::{Condvar, Mutex};
+
+pub struct Semaphore {
+    lock: Mutex<usize>,
+    cvar: Condvar,
+}
+
+pub struct SemaphoreGuard<'a> {
+    sem: &'a Semaphore,
+}
+
+impl Semaphore {
+    /// Creates a new semaphore with the initial count specified
+    pub fn new(count: usize) -> Semaphore {
+        Semaphore {
+            lock: Mutex::new(count),
+            cvar: Condvar::new(),
+        }
+    }
+
+    /// Acquires a resource of this semaphore, blocking the current thread
+    pub fn acquire(&self) {
+        let mut count = self.lock.lock().unwrap();
+        while *count == 0 {
+            count = self.cvar.wait(count).unwrap();
+        }
+        *count -= 1;
+    }
+
+    /// Release a resource from this semaphore
+    pub fn release(&self) {
+        *self.lock.lock().unwrap() += 1;
+        self.cvar.notify_one();
+    }
+
+    /// Acquires a resource of this semaphore, returning an RAII guard
+    pub fn access(&self) -> SemaphoreGuard {
+        self.acquire();
+        SemaphoreGuard { sem: self }
+    }
+}
+
+impl<'a> Drop for SemaphoreGuard<'a> {
+    fn drop(&mut self) {
+        self.sem.release();
+    }
+}


### PR DESCRIPTION
Spawn threads within a semaphore, matching the number of available logical cores for increased preview speed.