### PR TITLE
fix: escape `'` char in trash operations

### DIFF
--- a/src/io/io_worker.rs
+++ b/src/io/io_worker.rs
@@ -356,7 +356,11 @@ fn trash_file<P>(file_path: P) -> AppResult
 where
     P: AsRef<path::Path>,
 {
-    let file_path_str = file_path.as_ref().as_os_str().to_string_lossy();
+    let file_path_str = file_path
+        .as_ref()
+        .as_os_str()
+        .to_string_lossy()
+        .replace("'", "'\\''");
 
     let clipboards = [
         ("gio trash", format!("gio trash -- '{}'", file_path_str)),

--- a/src/io/io_worker.rs
+++ b/src/io/io_worker.rs
@@ -360,7 +360,7 @@ where
         .as_ref()
         .as_os_str()
         .to_string_lossy()
-        .replace("'", "'\\''");
+        .replace('\'', "'\\''");
 
     let clipboards = [
         ("gio trash", format!("gio trash -- '{}'", file_path_str)),


### PR DESCRIPTION
Without this any attempt to trash a file with a `'` in its path results in an error.