### PR TITLE
fix: clear numbered command buffer on cursor move

### DIFF
--- a/src/commands/numbered_command.rs
+++ b/src/commands/numbered_command.rs
@@ -57,6 +57,7 @@ pub fn numbered_command(
                                 let _ =
                                     command.numbered_execute(num_prefix, context, backend, keymap);
                             }
+                            return Ok(());
                         }
                         _ => {
                             return Err(AppError::new(


### PR DESCRIPTION
Really simple fix to a quite annoying issue