### PR TITLE
feat: add `--reverse` flag to sort methods

### DIFF
--- a/docs/configuration/keymap.toml.md
+++ b/docs/configuration/keymap.toml.md
@@ -152,7 +152,13 @@ function joshuto() {
 - `sort lexical`: sort lexically (`10.txt` comes before `2.txt`)
 - `sort natural`: sort naturally (`2.txt` comes before `10.txt`)
 - `sort mtime`: sort via last modified time
+- `sort size`: sort by file size
+- `sort ext`: sort by extension
 - `sort reverse`: reverse the sorting
+
+All methods (except `reverse`) support the `--reverse` flag:
+- `--reverse=true` applies sort method and sets reverse to `true`
+- `--reverse=false` applies sort method and sets reverse to `false`
 
 ### `linemode`: change the line-mode (textual representation of files and directories in the “current view”)
 

--- a/src/commands/sort.rs
+++ b/src/commands/sort.rs
@@ -5,13 +5,18 @@ use crate::history::DirectoryHistory;
 
 use super::reload;
 
-pub fn set_sort(context: &mut AppContext, method: SortType) -> AppResult {
+pub fn set_sort(context: &mut AppContext, method: SortType, reverse: Option<bool>) -> AppResult {
     let curr_tab = context.tab_context_mut().curr_tab_mut();
     curr_tab
         .option_mut()
         .sort_options_mut()
         .set_sort_method(method);
     curr_tab.history_mut().depreciate_all_entries();
+
+    if let Some(r) = reverse {
+        curr_tab.option_mut().sort_options_mut().reverse = r;
+    }
+
     refresh(context)
 }
 

--- a/src/key_command/command.rs
+++ b/src/key_command/command.rs
@@ -153,7 +153,10 @@ pub enum Command {
         initial: char,
     },
 
-    Sort(SortType),
+    Sort {
+        sort_type: SortType,
+        reverse: Option<bool>,
+    },
     SortReverse,
 
     FilterGlob {

--- a/src/key_command/impl_appcommand.rs
+++ b/src/key_command/impl_appcommand.rs
@@ -79,7 +79,7 @@ impl AppCommand for Command {
             Self::Flat { .. } => CMD_FLAT,
             Self::NumberedCommand { .. } => CMD_NUMBERED_COMMAND,
 
-            Self::Sort(_) => CMD_SORT,
+            Self::Sort { .. } => CMD_SORT,
             Self::SortReverse => CMD_SORT_REVERSE,
 
             Self::FilterGlob { .. } => CMD_FILTER_GLOB,

--- a/src/key_command/impl_appexecute.rs
+++ b/src/key_command/impl_appexecute.rs
@@ -135,7 +135,7 @@ impl AppExecute for Command {
             } => case_sensitivity::set_case_sensitivity(context, *case_sensitivity, *set_type),
             Self::SetMode => set_mode::set_mode(context, backend),
             Self::ShowTasks => show_tasks::show_tasks(context, backend, keymap_t),
-            Self::Sort(t) => sort::set_sort(context, *t),
+            Self::Sort { sort_type, reverse } => sort::set_sort(context, *sort_type, *reverse),
             Self::SetLineMode(mode) => linemode::set_linemode(context, *mode),
             Self::SortReverse => sort::toggle_reverse(context),
             Self::SubProcess { words, mode } => {

--- a/src/key_command/impl_comment.rs
+++ b/src/key_command/impl_comment.rs
@@ -119,7 +119,7 @@ impl CommandComment for Command {
             Self::Flat { .. } => "Flattern directory list",
             Self::NumberedCommand { .. } => "Jump via input number",
 
-            Self::Sort(sort_type) => match sort_type {
+            Self::Sort { sort_type, .. } => match sort_type {
                 SortType::Lexical => "Sort lexically",
                 SortType::Mtime => "Sort by modification time",
                 SortType::Natural => "Sort naturally",

--- a/src/key_command/impl_display.rs
+++ b/src/key_command/impl_display.rs
@@ -49,7 +49,17 @@ impl std::fmt::Display for Command {
             Self::SearchRegex { pattern } => write!(f, "{} {}", self.command(), pattern),
             Self::SearchString { pattern } => write!(f, "{} {}", self.command(), pattern),
             Self::SubProcess { words, .. } => write!(f, "{} {:?}", self.command(), words),
-            Self::Sort(t) => write!(f, "{} {}", self.command(), t),
+            Self::Sort { sort_type, reverse } => write!(
+                f,
+                "{} {}{}",
+                self.command(),
+                sort_type,
+                match reverse {
+                    Some(true) => " --reverse=true",
+                    Some(false) => " --reverse=false",
+                    None => "",
+                },
+            ),
             Self::TabSwitch { offset } => write!(f, "{} {}", self.command(), offset),
             Self::TabSwitchIndex { index } => write!(f, "{} {}", self.command(), index),
             _ => write!(f, "{}", self.command()),


### PR DESCRIPTION
This can be useful to get to a specific order with just a command without the need of toggling reverse each time, for example when I switch to `mtime` sort I often want newer files on top, which is reversed.