### PR TITLE
fix: restore line numbers

### DIFF
--- a/src/config/clean/theme/style.rs
+++ b/src/config/clean/theme/style.rs
@@ -9,7 +9,6 @@ pub struct AppStyle {
     pub fg: style::Color,
     pub bg: style::Color,
     pub prefix: String,
-    pub prefix_width: usize,
     pub modifier: style::Modifier,
 }
 
@@ -22,9 +21,8 @@ impl AppStyle {
         self.fg = fg;
         self
     }
-    pub fn set_prefix(mut self, prefix: String, prefix_width: usize) -> Self {
+    pub fn set_prefix(mut self, prefix: String) -> Self {
         self.prefix = prefix;
-        self.prefix_width = prefix_width;
         self
     }
 
@@ -44,7 +42,6 @@ impl std::default::Default for AppStyle {
             fg: default_color(),
             bg: default_color(),
             prefix: String::new(),
-            prefix_width: 0,
             modifier: style::Modifier::empty(),
         }
     }

--- a/src/config/raw/theme/style.rs
+++ b/src/config/raw/theme/style.rs
@@ -1,7 +1,6 @@
 use colors_transform::{Color, Rgb};
 use ratatui::style::{self, Style};
 use serde::Deserialize;
-use unicode_width::UnicodeWidthStr;
 
 use crate::config::clean::theme::style::AppStyle;
 
@@ -111,8 +110,6 @@ impl AppStyleRaw {
     pub fn to_style_theme(&self) -> AppStyle {
         let bg = Self::str_to_color(self.bg.as_str());
         let fg = Self::str_to_color(self.fg.as_str());
-        let prefix = self.prefix.clone();
-        let prefix_width = prefix.width();
 
         let mut modifier = style::Modifier::empty();
         if self.bold {
@@ -128,7 +125,7 @@ impl AppStyleRaw {
         AppStyle::default()
             .set_fg(fg)
             .set_bg(bg)
-            .set_prefix(prefix, prefix_width)
+            .set_prefix(self.prefix.clone())
             .insert(modifier)
     }
 

--- a/src/ui/widgets/tui_dirlist_detailed.rs
+++ b/src/ui/widgets/tui_dirlist_detailed.rs
@@ -95,8 +95,7 @@ impl<'a> Widget for TuiDirListDetailed<'a> {
 
                 buf.set_string(x, y + i as u16, space_fill.as_str(), style);
 
-                let (prefix, prefix_width) = style::entry_prefix(entry);
-                let mut prefix = prefix.to_string();
+                let mut prefix = style::entry_prefix(entry).to_string();
                 let line_number_prefix = match line_num_style {
                     LineNumberStyle::None => "".to_string(),
                     _ if ix == curr_index => format!("{:<1$} ", curr_index + 1, max_index_length),
@@ -118,7 +117,6 @@ impl<'a> Widget for TuiDirListDetailed<'a> {
                     self.tab_display_options.linemode,
                     drawing_width - 1,
                     &prefix,
-                    prefix_width,
                 );
             });
     }
@@ -135,7 +133,6 @@ fn get_entry_size_string(entry: &JoshutoDirEntry) -> String {
     }
 }
 
-#[allow(clippy::too_many_arguments)]
 fn print_entry(
     config: &AppConfig,
     buf: &mut Buffer,
@@ -145,7 +142,6 @@ fn print_entry(
     linemode: LineMode,
     drawing_width: usize,
     prefix: &str,
-    prefix_width: usize,
 ) {
     let symlink_string = match entry.metadata.link_type() {
         LinkType::Normal => "",
@@ -185,6 +181,7 @@ fn print_entry(
     );
 
     // draw prefix first
+    let prefix_width = prefix.width();
     buf.set_stringn(x, y, prefix, prefix_width, Style::default());
     let x = x + prefix_width as u16;
 

--- a/src/ui/widgets/tui_dirlist_detailed.rs
+++ b/src/ui/widgets/tui_dirlist_detailed.rs
@@ -133,6 +133,7 @@ fn get_entry_size_string(entry: &JoshutoDirEntry) -> String {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn print_entry(
     config: &AppConfig,
     buf: &mut Buffer,

--- a/src/util/style.rs
+++ b/src/util/style.rs
@@ -48,20 +48,14 @@ pub fn entry_style(config: &AppConfig, entry: &JoshutoDirEntry) -> Style {
     }
 }
 
-pub fn entry_prefix(entry: &JoshutoDirEntry) -> (&str, usize) {
+pub fn entry_prefix(entry: &JoshutoDirEntry) -> &str {
     if entry.is_visual_mode_selected() {
-        return (
-            THEME_T.visual_mode_selection.prefix.as_str(),
-            THEME_T.visual_mode_selection.prefix_width,
-        );
+        &THEME_T.visual_mode_selection.prefix
+    } else if entry.is_permanent_selected() {
+        &THEME_T.selection.prefix
+    } else {
+        ""
     }
-    if entry.is_permanent_selected() {
-        return (
-            THEME_T.selection.prefix.as_str(),
-            THEME_T.selection.prefix_width,
-        );
-    }
-    ("", 0)
 }
 
 fn default_style(


### PR DESCRIPTION
I noticed that the eager evaluation of prefix width introduced in 1822104 ignores the line number part, which is pushed to prefix later.