### PR TITLE
feat: add support for %s and %p as first argument to subprocess commands

### DIFF
--- a/src/commands/custom_search.rs
+++ b/src/commands/custom_search.rs
@@ -1,5 +1,5 @@
 use super::change_directory::change_directory;
-use super::sub_process::current_filenames;
+use super::sub_process::current_files;
 use crate::commands::cursor_move;
 use crate::context::AppContext;
 use crate::error::{AppError, AppErrorKind, AppResult};
@@ -26,7 +26,7 @@ pub fn custom_search(
         .command
         .clone();
 
-    let current_filenames = current_filenames(context);
+    let current_filenames: Vec<&str> = current_files(context).iter().map(|f| f.0).collect();
 
     let text = custom_command.replace("%s", &current_filenames.join(" "));
     let text = text.replace(

--- a/src/commands/sub_process.rs
+++ b/src/commands/sub_process.rs
@@ -125,10 +125,10 @@ pub fn sub_process(
             let res = execute_sub_process(context, words, mode);
             backend.terminal_restore()?;
             let _ = reload::soft_reload_curr_tab(context);
+            res?;
             context
                 .message_queue_mut()
                 .push_info(format!("Finished: {}", words.join(" ")));
-            res?;
         }
         SubprocessCallMode::Spawn => {
             execute_sub_process(context, words, mode)?;

--- a/src/commands/sub_process.rs
+++ b/src/commands/sub_process.rs
@@ -73,7 +73,7 @@ fn execute_sub_process(
                     } else {
                         Err(std::io::Error::new(
                             std::io::ErrorKind::Other,
-                            format!("Command failed with {:?}", status),
+                            format!("Command failed with {}", status),
                         ))
                     }
                 }
@@ -101,7 +101,7 @@ fn execute_sub_process(
             } else {
                 Err(std::io::Error::new(
                     std::io::ErrorKind::Other,
-                    format!("Command failed with {:?}", output.status),
+                    format!("Command failed with {}", output.status),
                 ))
             }
         }

--- a/src/commands/sub_process.rs
+++ b/src/commands/sub_process.rs
@@ -38,11 +38,9 @@ fn execute_sub_process(
 ) -> std::io::Result<()> {
     let current_files = current_files(context);
     let command_base = if current_files.len() == 1 {
-        match words[0].as_str() {
-            "%s" | "./%s" => current_files[0].0.to_string(),
-            "%p" => current_files[0].1.to_string_lossy().to_string(),
-            cmd => cmd.to_string(),
-        }
+        words[0]
+            .replace("%s", current_files[0].0)
+            .replace("%p", &current_files[0].1.to_string_lossy())
     } else {
         words[0].clone()
     };


### PR DESCRIPTION
This allows to run the file under cursor (if executable) with `:shell %s`, `:shell ./%s` or `:shell %p`.

I also fixed a bug introduced in #495 which caused a panic when trying to run a file that doesn't exist or a non-executable file.