### PR TITLE
feat: add `--last` option to `new_tab` command

### DIFF
--- a/docs/configuration/keymap.toml.md
+++ b/docs/configuration/keymap.toml.md
@@ -237,7 +237,7 @@ All methods (except `reverse`) support the `--reverse` flag:
 
 ## Tabs
 
-### `new_tab [--current][--cursor][dir]`: opens a new tab
+### `new_tab [--last] [--current|--cursor|dir]`: opens a new tab
 
 - `new_tab`, without any argument, opens a new tab with the default directory.
 
@@ -246,6 +246,8 @@ All methods (except `reverse`) support the `--reverse` flag:
 - `new_tab some-dir` opens new tab with directory `some-dir`
 - `new_tab --current` opens new tab with the same directory as the current tab
 - `new_tab --cursor` opens new tab with the directory which is currently marked by the cursor
+- `new_tab --last` new tab will be placed at the end of the stack.
+  This is the only flag that can be combined with the others described above.
 
 ### `close_tab`: close current tab
 

--- a/src/commands/tab_ops.rs
+++ b/src/commands/tab_ops.rs
@@ -97,7 +97,7 @@ pub fn tab_switch_index(context: &mut AppContext, new_index: usize) -> AppResult
         _tab_switch(new_index - 1, context)?;
     } else if new_index > num_tabs {
         for _ in 0..(new_index - num_tabs) {
-            new_tab(context, &NewTabMode::Default)?;
+            new_tab(context, &NewTabMode::Default, true)?;
         }
         _tab_switch(new_index - 1, context)?;
     }
@@ -115,7 +115,7 @@ pub fn new_tab_home_path(context: &AppContext) -> path::PathBuf {
     }
 }
 
-pub fn new_tab(context: &mut AppContext, mode: &NewTabMode) -> AppResult {
+pub fn new_tab(context: &mut AppContext, mode: &NewTabMode, last: bool) -> AppResult {
     let new_tab_path = match mode {
         NewTabMode::Default => Ok(new_tab_home_path(context)),
         NewTabMode::CurrentTabDir => {
@@ -172,8 +172,13 @@ pub fn new_tab(context: &mut AppContext, mode: &NewTabMode) -> AppResult {
             .default_tab_display_option
             .clone();
         let tab = JoshutoTab::new(new_tab_path, new_tab_history, tab_display_options)?;
-        context.tab_context_mut().insert_tab(id, tab);
-        let new_index = context.tab_context_ref().len() - 1;
+        context.tab_context_mut().insert_tab(id, tab, last);
+        let new_index = if last {
+            context.tab_context_ref().len() - 1
+        } else {
+            context.tab_context_ref().index + 1
+        };
+
         context.tab_context_mut().index = new_index;
         _tab_switch(new_index, context)?;
         Ok(())

--- a/src/context/tab_context.rs
+++ b/src/context/tab_context.rs
@@ -51,9 +51,13 @@ impl TabContext {
         let id = &self.tab_order[self.index];
         self.tabs.get_mut(id).unwrap()
     }
-    pub fn insert_tab(&mut self, id: Uuid, tab: JoshutoTab) {
+    pub fn insert_tab(&mut self, id: Uuid, tab: JoshutoTab, last: bool) {
         self.tabs.insert(id, tab);
-        self.tab_order.push(id);
+        if last {
+            self.tab_order.push(id);
+        } else {
+            self.tab_order.insert(self.index + 1, id);
+        }
     }
     pub fn remove_tab(&mut self, id: &Uuid) -> Option<JoshutoTab> {
         let tab = self.tabs.remove(id);

--- a/src/key_command/command.rs
+++ b/src/key_command/command.rs
@@ -171,6 +171,7 @@ pub enum Command {
 
     NewTab {
         mode: NewTabMode,
+        last: bool,
     },
     CloseTab,
     TabSwitch {

--- a/src/key_command/impl_appexecute.rs
+++ b/src/key_command/impl_appexecute.rs
@@ -26,7 +26,7 @@ impl AppExecute for Command {
             Self::ParentDirectory => change_directory::parent_directory(context),
             Self::PreviousDirectory => change_directory::previous_directory(context),
 
-            Self::NewTab { mode } => tab_ops::new_tab(context, mode),
+            Self::NewTab { mode, last } => tab_ops::new_tab(context, mode, *last),
             Self::CloseTab => tab_ops::close_tab(context),
             Self::CommandLine { prefix, suffix } => command_line::read_and_execute(
                 context,

--- a/src/key_command/impl_from_str.rs
+++ b/src/key_command/impl_from_str.rs
@@ -124,8 +124,12 @@ impl std::str::FromStr for Command {
                 _ => Ok(Self::Quit(QuitAction::Noop)),
             }
         } else if command == CMD_NEW_TAB {
+            let new_arg = arg.split("--last").collect::<Vec<_>>().join(" ");
+            let last = arg != new_arg;
+
             Ok(Self::NewTab {
-                mode: NewTabMode::from_str(arg),
+                mode: NewTabMode::from_str(&new_arg),
+                last,
             })
         } else if command == CMD_CHANGE_DIRECTORY {
             match arg {

--- a/src/key_command/impl_from_str.rs
+++ b/src/key_command/impl_from_str.rs
@@ -124,7 +124,7 @@ impl std::str::FromStr for Command {
                 _ => Ok(Self::Quit(QuitAction::Noop)),
             }
         } else if command == CMD_NEW_TAB {
-            let new_arg = arg.split("--last").collect::<Vec<_>>().join(" ");
+            let new_arg = arg.split(" --last").collect::<Vec<_>>().join("");
             let last = arg != new_arg;
 
             Ok(Self::NewTab {

--- a/src/key_command/impl_from_str.rs
+++ b/src/key_command/impl_from_str.rs
@@ -124,8 +124,16 @@ impl std::str::FromStr for Command {
                 _ => Ok(Self::Quit(QuitAction::Noop)),
             }
         } else if command == CMD_NEW_TAB {
-            let new_arg = arg.split(" --last").collect::<Vec<_>>().join("");
-            let last = arg != new_arg;
+            let mut new_arg = arg.to_string();
+            let mut last = false;
+
+            for arg in arg.split_whitespace() {
+                if arg == "--last" {
+                    new_arg = new_arg.split("--last").collect();
+                    last = true;
+                    break;
+                }
+            }
 
             Ok(Self::NewTab {
                 mode: NewTabMode::from_str(&new_arg),

--- a/src/run.rs
+++ b/src/run.rs
@@ -52,7 +52,7 @@ pub fn run_loop(
         new_tab_history.insert_entries(dirlists);
 
         let tab = JoshutoTab::new(curr_path, new_tab_history, tab_display_options)?;
-        context.tab_context_mut().insert_tab(id, tab);
+        context.tab_context_mut().insert_tab(id, tab, true);
 
         // trigger a preview of child
         preview_default::load_preview(context, backend);


### PR DESCRIPTION
This changes `new_tab`'s default behavior, putting the new tab at current tab index + 1, adding the `--last` flag to push the new tab to the end.