### PR TITLE
fix: hide image preview in fzf and task view

### DIFF
--- a/src/commands/fzf.rs
+++ b/src/commands/fzf.rs
@@ -3,8 +3,8 @@ use std::process::{Command, Stdio};
 use std::str::from_utf8;
 
 use crate::config::clean::app::search::CaseSensitivity;
-use crate::context::AppContext;
 use crate::context::remove_external_preview;
+use crate::context::AppContext;
 use crate::error::{AppError, AppResult};
 use crate::ui::AppBackend;
 

--- a/src/commands/fzf.rs
+++ b/src/commands/fzf.rs
@@ -4,6 +4,7 @@ use std::str::from_utf8;
 
 use crate::config::clean::app::search::CaseSensitivity;
 use crate::context::AppContext;
+use crate::context::remove_external_preview;
 use crate::error::{AppError, AppResult};
 use crate::ui::AppBackend;
 
@@ -51,13 +52,13 @@ pub fn fzf_multi(
 }
 
 fn fzf_impl(
-    _context: &mut AppContext,
+    context: &mut AppContext,
     backend: &mut AppBackend,
     items: Vec<String>,
     args: Vec<String>,
 ) -> AppResult<String> {
+    remove_external_preview(context);
     backend.terminal_drop();
-    context.remove_external_preview();
 
     let mut cmd = Command::new("fzf");
     cmd.stdout(Stdio::piped()).args(&args);

--- a/src/commands/fzf.rs
+++ b/src/commands/fzf.rs
@@ -57,6 +57,7 @@ fn fzf_impl(
     args: Vec<String>,
 ) -> AppResult<String> {
     backend.terminal_drop();
+    context.remove_external_preview();
 
     let mut cmd = Command::new("fzf");
     cmd.stdout(Stdio::piped()).args(&args);

--- a/src/commands/show_tasks.rs
+++ b/src/commands/show_tasks.rs
@@ -1,5 +1,6 @@
 use crate::config::clean::keymap::AppKeyMapping;
 use crate::context::AppContext;
+use crate::context::remove_external_preview;
 use crate::error::AppResult;
 use crate::event::process_event;
 use crate::event::AppEvent;
@@ -14,7 +15,7 @@ pub fn show_tasks(
     keymap_t: &AppKeyMapping,
 ) -> AppResult {
     context.flush_event();
-    context.remove_external_preview();
+    remove_external_preview(context);
 
     let mut exit = false;
 

--- a/src/commands/show_tasks.rs
+++ b/src/commands/show_tasks.rs
@@ -1,6 +1,6 @@
 use crate::config::clean::keymap::AppKeyMapping;
-use crate::context::AppContext;
 use crate::context::remove_external_preview;
+use crate::context::AppContext;
 use crate::error::AppResult;
 use crate::event::process_event;
 use crate::event::AppEvent;

--- a/src/commands/show_tasks.rs
+++ b/src/commands/show_tasks.rs
@@ -14,6 +14,7 @@ pub fn show_tasks(
     keymap_t: &AppKeyMapping,
 ) -> AppResult {
     context.flush_event();
+    context.remove_external_preview();
 
     let mut exit = false;
 


### PR DESCRIPTION
I noticed that switching to fzf or task view with an image preview visible, it remains there covering part of the view, so this fixes the issue.