### PR TITLE
feat: Add mouse scrolling in file preview

### DIFF
--- a/src/commands/preview_cursor_move.rs
+++ b/src/commands/preview_cursor_move.rs
@@ -5,12 +5,12 @@ use crate::error::AppResult;
 use crate::preview::preview_file::PreviewFileState;
 
 fn preview_cursor_move(context: &mut AppContext, new_index: usize) -> AppResult {
-    let file_path: Option<PathBuf> = {
-        let curr_tab = context.tab_context_ref().curr_tab_ref();
-        let curr_list = curr_tab.curr_list_ref();
-        let curr_entry = curr_list.and_then(|c| c.curr_entry_ref());
-        curr_entry.map(|e| e.file_path().to_path_buf())
-    };
+    let file_path: Option<PathBuf> = context
+        .tab_context_ref()
+        .curr_tab_ref()
+        .curr_list_ref()
+        .and_then(|c| c.curr_entry_ref())
+        .map(|e| e.file_path().to_path_buf());
 
     let preview_context = context.preview_context_mut();
     if let Some(file_path) = file_path {
@@ -25,10 +25,12 @@ fn preview_cursor_move(context: &mut AppContext, new_index: usize) -> AppResult 
 
 pub fn preview_up(context: &mut AppContext, u: usize) -> AppResult {
     let new_index = {
-        let curr_tab = context.tab_context_ref().curr_tab_ref();
-        let curr_list = curr_tab.curr_list_ref();
-        let curr_entry = curr_list.and_then(|c| c.curr_entry_ref());
-        let file_path = curr_entry.map(|e| e.file_path());
+        let file_path = context
+            .tab_context_ref()
+            .curr_tab_ref()
+            .curr_list_ref()
+            .and_then(|c| c.curr_entry_ref())
+            .map(|e| e.file_path());
 
         let preview_context = context.preview_context_ref();
         if let Some(file_path) = file_path {
@@ -55,17 +57,26 @@ pub fn preview_up(context: &mut AppContext, u: usize) -> AppResult {
 
 pub fn preview_down(context: &mut AppContext, u: usize) -> AppResult {
     let new_index = {
-        let curr_tab = context.tab_context_ref().curr_tab_ref();
-        let curr_list = curr_tab.curr_list_ref();
-        let curr_entry = curr_list.and_then(|c| c.curr_entry_ref());
-        let file_path = curr_entry.map(|e| e.file_path());
+        let file_path = context
+            .tab_context_ref()
+            .curr_tab_ref()
+            .curr_list_ref()
+            .and_then(|c| c.curr_entry_ref())
+            .map(|e| e.file_path());
 
         let preview_context = context.preview_context_ref();
         if let Some(file_path) = file_path {
+            // TODO: scroll in child list
             if let Some(PreviewFileState::Success(data)) =
                 preview_context.previews_ref().get(file_path)
             {
-                Some(data.index + u)
+                if (data.index as isize)
+                    < (data.output.split('\n').count() as isize - u as isize - 3)
+                {
+                    Some(data.index + u)
+                } else {
+                    None
+                }
             } else {
                 None
             }

--- a/src/event/process_event.rs
+++ b/src/event/process_event.rs
@@ -273,7 +273,10 @@ pub fn process_mouse(
                     context.message_queue_mut().push_error(e.to_string());
                 }
             } else {
-                // TODO: scroll in child list
+                let command = Command::PreviewCursorMoveUp { offset: 1 };
+                if let Err(e) = command.execute(context, backend, keymap_t) {
+                    context.message_queue_mut().push_error(e.to_string());
+                }
             }
         }
         MouseEvent::Press(MouseButton::WheelDown, x, _) => {
@@ -288,7 +291,10 @@ pub fn process_mouse(
                     context.message_queue_mut().push_error(e.to_string());
                 }
             } else {
-                // TODO: scroll in child list
+                let command = Command::PreviewCursorMoveDown { offset: 1 };
+                if let Err(e) = command.execute(context, backend, keymap_t) {
+                    context.message_queue_mut().push_error(e.to_string());
+                }
             }
         }
         MouseEvent::Press(button @ MouseButton::Left, x, y)


### PR DESCRIPTION
- Add file preview scrolling with the mouse.
- Limit file preview scrolling to the last 3 lines to avoid scrolling way past the last line of the file.

Closes #535