### PR TITLE
XDG-thumb for preview & thumbs for non-image files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "allmytoes"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c7b3df50220b4e21b9923db076437d6fc7509d2aa7219b975e8545c1bacaf1c"
+dependencies = [
+ "byteorder",
+ "clap",
+ "dynfmt",
+ "flexi_logger",
+ "hex",
+ "image",
+ "imagesize",
+ "kamadak-exif",
+ "log",
+ "md5",
+ "mime",
+ "once_cell",
+ "pathdiff",
+ "percent-encoding",
+ "png",
+ "serde",
+ "serde_yaml",
+ "subprocess",
+ "temp-dir",
+ "xdg-mime",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -62,7 +90,7 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b0e348dcd256ba06d44d5deabc88a7c0e80ee7303158253ca069bcd9e9b7f57"
 dependencies = [
- "nom",
+ "nom 7.1.3",
  "ratatui",
  "thiserror",
 ]
@@ -114,6 +142,12 @@ dependencies = [
  "anstyle",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "arrayvec"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "autocfg"
@@ -458,6 +492,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
 
 [[package]]
+name = "dynfmt"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c298552016db86f0d49e5de09818dd86c536f66095013cc415f4f85744033f"
+dependencies = [
+ "erased-serde",
+ "lazy_static",
+ "regex",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
 name = "either"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -474,6 +522,15 @@ name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "erased-serde"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c138974f9d5e7fe373eb04df7cae98833802ae4b11c24ac7039a21d5af4b26c"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "errno"
@@ -554,6 +611,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "flexi_logger"
+version = "0.27.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469e584c031833564840fb0cdbce99bdfe946fd45480a188545e73a76f45461c"
+dependencies = [
+ "chrono",
+ "glob",
+ "is-terminal",
+ "lazy_static",
+ "log",
+ "nu-ansi-term 0.49.0",
+ "regex",
+ "thiserror",
+]
+
+[[package]]
 name = "flume"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -615,6 +688,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
 name = "globset"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -658,6 +737,18 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "home"
@@ -726,6 +817,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "imagesize"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "029d73f573d8e8d63e6d5020011d3255b28c3ba85d6cf870a07184ed23de9284"
+
+[[package]]
 name = "indexmap"
 version = "2.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -768,6 +865,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -814,6 +922,7 @@ dependencies = [
 name = "joshuto"
 version = "0.9.8"
 dependencies = [
+ "allmytoes",
  "alphanumeric-sort",
  "ansi-to-tui",
  "bitflags 2.4.2",
@@ -871,6 +980,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "kamadak-exif"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef4fc70d0ab7e5b6bafa30216a6b48705ea964cdfc29c050f2412295eba58077"
+dependencies = [
+ "mutate_once",
+]
+
+[[package]]
 name = "kqueue"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -901,6 +1019,19 @@ name = "lebe"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03087c2bad5e1034e8cace5926dec053fb3790248370865f5117a7d0213354c8"
+
+[[package]]
+name = "lexical-core"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6607c62aa161d23d17a9072cc5da0be67cdfc89d3afb1e8d9c842bebc2525ffe"
+dependencies = [
+ "arrayvec",
+ "bitflags 1.3.2",
+ "cfg-if",
+ "ryu",
+ "static_assertions",
+]
 
 [[package]]
 name = "libc"
@@ -991,14 +1122,26 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53304fff6ab1e597661eee37e42ea8c47a146fca280af902bb76bff8a896e523"
 dependencies = [
- "nu-ansi-term",
+ "nu-ansi-term 0.50.0",
 ]
+
+[[package]]
+name = "md5"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "memchr"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "minimal-lexical"
@@ -1027,6 +1170,12 @@ dependencies = [
  "wasi",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "mutate_once"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16cf681a23b4d0a43fc35024c176437f9dcd818db34e0f42ab456a0ee5ad497b"
 
 [[package]]
 name = "nibble_vec"
@@ -1062,6 +1211,17 @@ dependencies = [
 
 [[package]]
 name = "nom"
+version = "5.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08959a387a676302eebf4ddbcbc611da04285579f76f88ee0506c63b1a61dd4b"
+dependencies = [
+ "lexical-core",
+ "memchr",
+ "version_check",
+]
+
+[[package]]
+name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
@@ -1086,6 +1246,15 @@ dependencies = [
  "log",
  "mio",
  "walkdir",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.49.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c073d3c1930d0751774acf49e66653acecb416c3a54c6ec095a9b11caddb5a68"
+dependencies = [
  "windows-sys 0.48.0",
 ]
 
@@ -1514,12 +1683,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "1.0.116"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e17db7126d17feb94eb3fad46bf1a96b034e8aacbc2e775fe81505f8b0b2813"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -1649,6 +1842,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "subprocess"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c2e86926081dda636c546d8c5e641661049d7562a68f5488be4a1f7f66f6086"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1669,6 +1872,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "temp-dir"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f227968ec00f0e5322f9b8173c7a0cbcff6181a0a5b28e9892491c286277231"
 
 [[package]]
 name = "termion"
@@ -1837,6 +2046,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicase"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1874,6 +2092,12 @@ name = "unicode-xid"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "url"
@@ -2215,6 +2439,19 @@ name = "xdg"
 version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "213b7324336b53d2414b2db8537e56544d981803139155afa84f76eeebb7a546"
+
+[[package]]
+name = "xdg-mime"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87bf7b69bb50588d70a36e467be29d3df3e8c32580276d62eded9738c1a797aa"
+dependencies = [
+ "dirs-next",
+ "glob",
+ "mime",
+ "nom 5.1.3",
+ "unicase",
+]
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ categories = ['command-line-interface', 'command-line-utilities']
 strip = true
 
 [dependencies]
+allmytoes = "^0.4"
 alphanumeric-sort = "^1"
 ansi-to-tui = { version = "^3.1.0", optional = true }
 bitflags = { version = "^2", features = ["serde"] }

--- a/docs/configuration/joshuto.toml.md
+++ b/docs/configuration/joshuto.toml.md
@@ -116,6 +116,17 @@ max_preview_size = 2097152
 # Executable script for previews
 preview_script = "~/.config/joshuto/preview_file.sh"
 
+# Use thumbnail images according to the freedesktop.org (XDG) standard.
+# (https://specifications.freedesktop.org/thumbnail-spec/thumbnail-spec-latest.html)
+# This only affects Joshuto's internal image-thumbnail feature.
+# It does not affect the hook-script based previews.
+use_xdg_thumbs = true
+
+# The XDG thumb size used for the preview.
+# Allowed values are 'normal', 'large', 'xlarge', and 'xxlarge' with maximum edge lengths
+# of 128 px, 256 px, 512 px, and 1024 px respectively.
+xdg_thumb_size = "xlarge"
+
 # Configurations related to searching and selecting files
 [search]
 # Different case sensitivities for operations using substring matching

--- a/src/config/clean/app/preview/config.rs
+++ b/src/config/clean/app/preview/config.rs
@@ -1,5 +1,7 @@
 use std::path;
 
+use allmytoes::ThumbSize;
+
 use crate::{
     config::{
         raw::app::display::preview::{default_max_preview_size, PreviewOptionRaw, PreviewProtocol},
@@ -14,6 +16,8 @@ pub struct PreviewOption {
     pub max_preview_size: u64,
     pub preview_protocol: PreviewProtocol,
     pub preview_script: Option<path::PathBuf>,
+    pub use_xdg_thumbs: bool,
+    pub xdg_thumb_size: ThumbSize,
     pub preview_shown_hook_script: Option<path::PathBuf>,
     pub preview_removed_hook_script: Option<path::PathBuf>,
 }
@@ -23,6 +27,8 @@ impl std::default::Default for PreviewOption {
         Self {
             max_preview_size: default_max_preview_size(),
             preview_protocol: PreviewProtocol::Auto,
+            use_xdg_thumbs: true,
+            xdg_thumb_size: ThumbSize::XLarge,
             preview_script: None,
             preview_shown_hook_script: None,
             preview_removed_hook_script: None,
@@ -49,6 +55,8 @@ impl From<PreviewOptionRaw> for PreviewOption {
             max_preview_size: raw.max_preview_size,
             preview_protocol: raw.preview_protocol,
             preview_script,
+            use_xdg_thumbs: raw.use_xdg_thumbs,
+            xdg_thumb_size: raw.xdg_thumb_size.to_amt_size(),
             preview_shown_hook_script,
             preview_removed_hook_script,
         }

--- a/src/config/raw/app/display/preview.rs
+++ b/src/config/raw/app/display/preview.rs
@@ -1,8 +1,13 @@
+use allmytoes::ThumbSize;
 use ratatui_image::picker::ProtocolType;
 use serde::Deserialize;
 
 pub const fn default_max_preview_size() -> u64 {
     2 * 1024 * 1024 // 2 MB
+}
+
+pub const fn default_true() -> bool {
+    true
 }
 
 #[derive(Clone, Debug, Deserialize, Default)]
@@ -15,6 +20,27 @@ pub enum PreviewProtocol {
     ProtocolType(ProtocolType),
 }
 
+#[derive(Clone, Debug, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum XDGThumbSizes {
+    Normal,
+    Large,
+    #[default]
+    XLarge,
+    XXLarge,
+}
+
+impl XDGThumbSizes {
+    pub fn to_amt_size(&self) -> ThumbSize {
+        match &self {
+            XDGThumbSizes::Normal => ThumbSize::Normal,
+            XDGThumbSizes::Large => ThumbSize::Large,
+            XDGThumbSizes::XLarge => ThumbSize::XLarge,
+            XDGThumbSizes::XXLarge => ThumbSize::XXLarge,
+        }
+    }
+}
+
 #[derive(Clone, Debug, Deserialize)]
 pub struct PreviewOptionRaw {
     #[serde(default = "default_max_preview_size")]
@@ -23,18 +49,25 @@ pub struct PreviewOptionRaw {
     pub preview_protocol: PreviewProtocol,
     #[serde(default)]
     pub preview_script: Option<String>,
+    #[serde(default = "default_true")]
+    pub use_xdg_thumbs: bool,
+    #[serde(default)]
+    pub xdg_thumb_size: XDGThumbSizes,
     #[serde(default)]
     pub preview_shown_hook_script: Option<String>,
     #[serde(default)]
     pub preview_removed_hook_script: Option<String>,
 }
 
+// This should be deleted maybe. I don't see where it is invoked.
 impl std::default::Default for PreviewOptionRaw {
     fn default() -> Self {
         Self {
             max_preview_size: default_max_preview_size(),
             preview_protocol: PreviewProtocol::Auto,
             preview_script: None,
+            use_xdg_thumbs: true,
+            xdg_thumb_size: XDGThumbSizes::XLarge,
             preview_shown_hook_script: None,
             preview_removed_hook_script: None,
         }

--- a/src/context/app_context.rs
+++ b/src/context/app_context.rs
@@ -12,6 +12,7 @@ use crate::event::{AppEvent, Events};
 use crate::preview::preview_file::PreviewFileState;
 use crate::ui::AppBackend;
 use crate::Args;
+use allmytoes::{AMTConfiguration, AMT};
 use notify::{RecursiveMode, Watcher};
 use ratatui_image::picker::Picker;
 use std::path;
@@ -88,6 +89,12 @@ impl AppContext {
         let watched_paths = HashSet::with_capacity(3);
 
         let preview_script = config.preview_options_ref().preview_script.clone();
+        let allmytoes = if config.preview_options_ref().use_xdg_thumbs {
+            Some(AMT::new(&AMTConfiguration::default()))
+        } else {
+            None
+        };
+        let xdg_thumb_size = config.preview_options_ref().xdg_thumb_size;
 
         Self {
             quit: QuitAction::DoNot,
@@ -99,7 +106,13 @@ impl AppContext {
             search_context: None,
             message_queue: MessageQueue::new(),
             worker_context: WorkerContext::new(event_tx.clone()),
-            preview_context: PreviewContext::new(picker, preview_script, event_tx),
+            preview_context: PreviewContext::new(
+                picker,
+                preview_script,
+                allmytoes,
+                xdg_thumb_size,
+                event_tx,
+            ),
             ui_context: UiContext { layout: vec![] },
             commandline_context,
             watcher,


### PR DESCRIPTION
This implements a cache for thumbnails and image previews for non-image file formats, like videos and PDFs.
This patch extends the inbuilt image preview feature (285df85) by integrating the `allmytoes` crate and using its thumbnails instead of the actual file being previewed.

The image-preview feature uses the XDG-(freedesktop.org-) specified thumbnail-cache to re-use existing thumbs and to store newly created thumbs.
(https://specifications.freedesktop.org/thumbnail-spec/thumbnail-spec-latest.html)

This increases performance for the image-preview because the preview does not need to load the full-sized version of the image and does not need to scale it down every time, once the thumbnail has been created. Also, thumbnails are now shared with other programs that use the XDG-thumb cache.

Furthermore, the new way to obtain thumbs allows to show image-previews for file types other than images. Existing thumbnails are shown for any file type. New thumbnails can be created for many video formats, PDF files, Postscript files, and SVGs. Users can also add “providers” for other file-types by configuring `allmytoes`.

The XDG-thumb feature can be disabled, and the thumbnail-size can be changed, both in `joshuto.toml`. The documentation has been extended, the whole image-preview page has been enhanced a little.