### PR TITLE
Feat: Human readable preview size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -289,6 +289,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
+name = "bytesize"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3e368af43e418a04d52505cf3dbc23dda4e3407ae2fa99fd0e4f308ce546acc"
+
+[[package]]
 name = "cassowary"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1067,6 +1073,7 @@ dependencies = [
  "alphanumeric-sort",
  "ansi-to-tui",
  "bitflags 2.6.0",
+ "bytesize",
  "chrono",
  "clap",
  "clap_complete",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ unicode-width = "^0"
 walkdir = "^2"
 whoami = "^1"
 xdg = "^2"
+bytesize = "1.3.0"
 
 [dependencies.nix]
 version = "^0"

--- a/config/joshuto.toml
+++ b/config/joshuto.toml
@@ -39,7 +39,7 @@ directories_first = true
 reverse = false
 
 [preview]
-max_preview_size = 2097152                           # 2MB
+max_preview_size = "2MB"                           # 2MB
 preview_script = "~/.config/joshuto/preview_file.sh" # make sure it's marked as executable
 
 [search]

--- a/docs/configuration/joshuto.toml.md
+++ b/docs/configuration/joshuto.toml.md
@@ -33,8 +33,8 @@ watch_files = true
 # - `:mkdir ./b` keeps the cursor where it was
 focus_on_create = true
 
-# The maximum file size to show a preview for
-max_preview_size = 2097152 # 2MB
+# The maximum file size to show a preview for, it can be "2 MB", "2 Mb" or "2097152"
+max_preview_size = "2 MB"
 
 # Update the zoxide database with every navigation type instead of only with the z command
 zoxide_update = false


### PR DESCRIPTION
add `bytesize` for parse the bytes string

just change the deserialize function for `max_preview_size` and change the default config to "2MiB" and change the doc