### PR TITLE
configure preview image background color via theme.toml

### DIFF
--- a/config/theme.toml
+++ b/config/theme.toml
@@ -2,6 +2,8 @@
 ## General
 ##########################################
 lscolors_enabled = false
+# The image preview background color, only RGB colors are accepted.
+# preview_background = "#FFFFFF"
 
 ##########################################
 ## Tabs

--- a/docs/image_previews/README.md
+++ b/docs/image_previews/README.md
@@ -21,6 +21,8 @@ preview_protocol = "halfblocks"
 ...
 ```
 
+The background color can be configured in `theme.toml`.
+
 ## XDG-Thumbnails and thumbnails for non-image files
 
 By default, Joshuto uses thumbnails and the

--- a/src/config/theme/mod.rs
+++ b/src/config/theme/mod.rs
@@ -7,6 +7,7 @@ pub mod theme_raw;
 use std::collections::HashMap;
 
 use lscolors::LsColors;
+use ratatui::style::Color;
 
 use crate::constants::config::THEME_CONFIG;
 use crate::error::AppResult;
@@ -16,6 +17,8 @@ use crate::types::config_type::ConfigType;
 use style::AppStyle;
 use tab::TabTheme;
 use theme_raw::AppThemeRaw;
+
+use self::style_raw::AppStyleRaw;
 
 #[derive(Clone, Debug)]
 pub struct AppTheme {
@@ -30,6 +33,7 @@ pub struct AppTheme {
     pub socket: AppStyle,
     pub ext: HashMap<String, AppStyle>,
     pub lscolors: Option<LsColors>,
+    pub preview_background: Color,
 }
 
 impl AppTheme {
@@ -81,6 +85,7 @@ impl From<AppThemeRaw> for AppTheme {
         } else {
             None
         };
+        let preview_background = AppStyleRaw::str_to_color(&raw.preview_background);
 
         Self {
             selection,
@@ -94,6 +99,7 @@ impl From<AppThemeRaw> for AppTheme {
             ext,
             tabs: TabTheme::from(tabs),
             lscolors,
+            preview_background,
         }
     }
 }

--- a/src/config/theme/theme_raw.rs
+++ b/src/config/theme/theme_raw.rs
@@ -28,4 +28,6 @@ pub struct AppThemeRaw {
     pub ext: HashMap<String, AppStyleRaw>,
     #[serde(default)]
     pub lscolors_enabled: bool,
+    #[serde(default)]
+    pub preview_background: String,
 }

--- a/src/types/state/app_state.rs
+++ b/src/types/state/app_state.rs
@@ -2,6 +2,7 @@ use std::collections::HashSet;
 use std::sync::mpsc;
 
 use allmytoes::{AMTConfiguration, AMT};
+use ratatui::style::Color;
 use ratatui_image::picker::Picker;
 
 use crate::commands::quit::QuitAction;
@@ -12,7 +13,7 @@ use crate::types::state::{
     CommandLineState, MessageQueue, PreviewState, TabState, UiState, WorkerState,
 };
 
-use crate::Args;
+use crate::{Args, THEME_T};
 
 use super::{FileManagerState, ThreadPool};
 
@@ -30,6 +31,10 @@ impl AppState {
     pub fn new(config: AppConfig, args: Args) -> Self {
         let picker = if config.preview_options.preview_shown_hook_script.is_none() {
             Picker::from_termios().ok().and_then(|mut picker| {
+                picker.background_color = match THEME_T.preview_background {
+                    Color::Rgb(r, g, b) => Some(image::Rgb([r, g, b])),
+                    _ => None,
+                };
                 match config.preview_options.preview_protocol {
                     PreviewProtocol::Auto => {
                         picker.guess_protocol(); // Must run before Events::new() because it makes ioctl calls.


### PR DESCRIPTION
https://github.com/benjajaja/ratatui-image/issues/21

![image](https://github.com/kamiyaa/joshuto/assets/310215/83fb9e83-a3dc-4ae5-bcc7-68a2fb5e5587)
Due to ratatui's immediate-mode nature, the cells behind the image must be "skipped" so that nothing draws over the image. In other words, the cells behind the image still have whatever was drawn last time before they were marked skipped for the image. Thus, the image must always fill the cells/area, and the frame cannot be made transparent.

This PR makes the background color configurable via theme.toml. It could also be done via `joshuto.toml`, which is what I initially did, so I could revert to that. I am not sure which is better, the goal here is essentially to make previews look good in terminals with white background, but it actually also applies to any terminal theme background color that isn't pitch black.

Closes #521 