### PR TITLE
refactor: replace manual sign detection with format spec "+"

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -79,12 +79,7 @@ lazy_static! {
     static ref HOSTNAME: String = whoami::fallible::hostname().unwrap_or("No Hostname".to_string());
 
     static ref TIMEZONE_STR: String = {
-        let offset = chrono::Local::now().offset().local_minus_utc() / 3600;
-        if offset.is_positive() {
-            format!(" UTC+{} ", offset.abs())
-        } else {
-            format!(" UTC-{} ", offset.abs())
-        }
+        format!(" UTC{:+} ", chrono::Local::now().offset().local_minus_utc() / 3600)
     };
 }
 

--- a/src/types/command/impl_completion.rs
+++ b/src/types/command/impl_completion.rs
@@ -45,9 +45,7 @@ impl CommandCompletion for Command {
                 "insensitive",
                 "sensitive",
             ]),
-            CMD_SET_DISPLAY_MODE => CompletionKind::Custom(vec![
-                "default", "minimal", "hsplit",
-            ]),
+            CMD_SET_DISPLAY_MODE => CompletionKind::Custom(vec!["default", "minimal", "hsplit"]),
             CMD_SET_LINEMODE => CompletionKind::Custom(vec![
                 "all", "group", "mtime", "none", "perm", "size", "user",
             ]),

--- a/src/types/command/impl_from_str.rs
+++ b/src/types/command/impl_from_str.rs
@@ -558,9 +558,9 @@ impl std::str::FromStr for Command {
                 "minimal" => Ok(Self::SetDisplayMode(DisplayMode::Minimal)),
                 "hsplit" => Ok(Self::SetDisplayMode(DisplayMode::HSplit)),
                 _ => Err(AppError::new(
-                        AppErrorKind::InvalidParameters,
-                        format!("{}: Unknown option '{}'", command, arg),
-                ))
+                    AppErrorKind::InvalidParameters,
+                    format!("{}: Unknown option '{}'", command, arg),
+                )),
             }
         } else if command == CMD_SET_LINEMODE {
             Ok(Self::SetLineMode(LineMode::from_string(arg)?))


### PR DESCRIPTION
- According to [the documentation of std::fmt](https://doc.rust-lang.org/std/fmt/index.html#sign0):
> *\+* - This is intended for numeric types and indicates that the sign should always be printed. By default only the negative sign of signed values is printed, and the sign of positive or unsigned values is omitted. This flag indicates that the correct sign (+ or -) should always be printed.