### PR TITLE
update: hide filter indicator if filter text is empty

### DIFF
--- a/src/types/state/matcher.rs
+++ b/src/types/state/matcher.rs
@@ -130,6 +130,15 @@ impl MatchState {
     pub fn is_none(&self) -> bool {
         matches!(self, Self::None)
     }
+
+    pub fn is_empty(&self) -> bool {
+        match self {
+            Self::Glob(glob_matcher) => false, // todo
+            Self::Regex(regex) => regex.as_str().is_empty(),
+            Self::String { pattern, .. } => pattern.is_empty(),
+            Self::None => true,
+        }
+    }
 }
 
 impl Display for MatchState {

--- a/src/ui/widgets/tui_footer.rs
+++ b/src/ui/widgets/tui_footer.rs
@@ -92,7 +92,9 @@ impl<'a> Widget for TuiFooter<'a> {
                     ),
                     Span::styled(
                         match self.tab_options.dirlist_options_ref(&path.to_path_buf()) {
-                            Some(opt) if !opt.filter_state_ref().is_none() => {
+                            // :filter (without filter text) will go back to normal
+                            // so, if filter_state is empty, we don't show the filter indicator
+                            Some(opt) if !opt.filter_state_ref().is_none() && !opt.filter_state_ref().is_empty() => {
                                 format!("filter:{} ", opt.filter_state_ref())
                             }
                             _ => "".to_owned(),


### PR DESCRIPTION
Run command ":filter" (without filter content), will cancel previous filter.
So, I think in this condition, maybe we don't need to show the filter indicator.