### PR TITLE
feat: add option to use current working directory with the %d keyword

### DIFF
--- a/docs/configuration/keymap.toml.md
+++ b/docs/configuration/keymap.toml.md
@@ -120,6 +120,7 @@ function joshuto() {
 ### `shell`: runs a shell command
 
 - `%s` and `%p` are substituted by a list of all selected files or by the file under the cursor, if none is selected
+- `%d` is substituted with the current directory's absolute path
 - When running the external program, the directory shown in Joshuto is set as “working directory”,
   the file names substituted for `%s` are given without path. If you want the absolute path, use `%p`.
 - Example: `:shell touch file.txt` will create a file called `file.txt`
@@ -138,12 +139,18 @@ function joshuto() {
 
 ### `spawn`: runs a shell command in the background
 
-- Supports `%s`and `%p`, just like the `shell` command.
+- Supports `%s`, `%p` and `%d`, just like the `shell` command.
 - Example for `keymap.toml`: To open all selected files or directories with `sxiv`,
   one can add a keybinding like this:
   ```toml
   keymap = [ //..
      { keys = [ "i" ], commands = ["spawn sxiv -t %s"] }
+  ]
+  ```
+- To open a new alacritty terminal in the current folder:
+  ```toml
+  keymap = [ // ..
+    { keys = [ "O" ], commands = ["spawn alacritty --working-directory %d"] }
   ]
   ```
 

--- a/src/commands/sub_process.rs
+++ b/src/commands/sub_process.rs
@@ -36,6 +36,10 @@ pub fn current_files(app_state: &AppState) -> Vec<(&str, &Path)> {
     result
 }
 
+fn current_dir(app_state: &AppState) -> &Path {
+    app_state.state.tab_state_ref().curr_tab_ref().get_cwd()
+}
+
 fn execute_sub_process(
     app_state: &mut AppState,
     words: &[String],
@@ -64,6 +68,9 @@ fn execute_sub_process(
                 for (_, file_path) in &current_files {
                     command.arg(file_path);
                 }
+            }
+            "%d" => {
+                command.arg(current_dir(app_state));
             }
             s => {
                 command.arg(s);


### PR DESCRIPTION
Implement a new keyword for spawn and shell commands, `%d`, allowing the use of current working directory as parameter instead of the selected file(s).

Example: to open a new alacritty terminal in the current folder:
  ```toml
  keymap = [ // ..
    { keys = [ "O" ], commands = ["spawn alacritty --working-directory %d"] }
  ]
  ```

Related to #541 and #456