### PR TITLE
feat: add navigation history

### DIFF
--- a/docs/configuration/keymap.toml.md
+++ b/docs/configuration/keymap.toml.md
@@ -265,6 +265,10 @@ All methods (except `reverse`) support the `--reverse` flag:
 - `cd ~`: go to home directory
 - `cd -`: go to previous directory in history (If it exists)
 
+### `history_next`: go to next dir in navigation history
+
+### `history_prev`: go to previous dir in navigation history
+
 ### `open`: open file or directory
 
 - if joshuto does not know how to open the file format (via extension currently),

--- a/src/commands/history.rs
+++ b/src/commands/history.rs
@@ -1,0 +1,46 @@
+use std::path::PathBuf;
+
+use crate::error::AppResult;
+use crate::types::state::AppState;
+
+use super::change_directory;
+
+fn next_or_prev(app_state: &mut AppState, path_opt: Option<PathBuf>) -> AppResult {
+    if let Some(path) = path_opt {
+        if !matches!(path.try_exists(), Ok(true)) {
+            app_state
+                .state
+                .tab_state_mut()
+                .curr_tab_mut()
+                .navigation_history_mut()
+                .remove_current();
+            return next(app_state);
+        }
+
+        change_directory::cd(&path, app_state, false)?;
+    }
+
+    Ok(())
+}
+
+pub fn next(app_state: &mut AppState) -> AppResult {
+    let next = app_state
+        .state
+        .tab_state_mut()
+        .curr_tab_mut()
+        .navigation_history_mut()
+        .next()
+        .cloned();
+    next_or_prev(app_state, next)
+}
+
+pub fn prev(app_state: &mut AppState) -> AppResult {
+    let prev = app_state
+        .state
+        .tab_state_mut()
+        .curr_tab_mut()
+        .navigation_history_mut()
+        .prev()
+        .cloned();
+    next_or_prev(app_state, prev)
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -14,6 +14,7 @@ pub mod filter_regex;
 pub mod filter_string;
 pub mod flat;
 pub mod fzf;
+pub mod history;
 pub mod line_nums;
 pub mod linemode;
 pub mod new_directory;

--- a/src/commands/open_file.rs
+++ b/src/commands/open_file.rs
@@ -163,7 +163,7 @@ pub fn open(app_state: &mut AppState, backend: &mut AppBackend) -> AppResult {
         None => (),
         Some(entry) if entry.file_path().is_dir() => {
             let path = entry.file_path().to_path_buf();
-            change_directory::cd(path.as_path(), app_state)?;
+            change_directory::cd(path.as_path(), app_state, true)?;
             reload::soft_reload_curr_tab(app_state)?;
         }
         Some(entry) => {

--- a/src/commands/parent_cursor_move.rs
+++ b/src/commands/parent_cursor_move.rs
@@ -27,7 +27,7 @@ pub fn parent_cursor_move(app_state: &mut AppState, new_index: usize) -> AppResu
         }
         if let Some(path) = path.as_ref() {
             cwd::set_current_dir(path)?;
-            curr_tab.set_cwd(path);
+            curr_tab.set_cwd(path, true);
         }
     }
     Ok(())

--- a/src/constants/command_name.rs
+++ b/src/constants/command_name.rs
@@ -20,6 +20,8 @@ cmd_constants![
     (CMD_CHANGE_DIRECTORY, "cd"),
     (CMD_PARENT_DIRECTORY, "cd .."),
     (CMD_PREVIOUS_DIRECTORY, "cd -"),
+    (CMD_HISTORY_NEXT, "history_next"),
+    (CMD_HISTORY_PREV, "history_prev"),
     (CMD_NEW_TAB, "new_tab"),
     (CMD_CLOSE_TAB, "close_tab"),
     (CMD_CUT_FILES, "cut_files"),

--- a/src/tab/nav_history.rs
+++ b/src/tab/nav_history.rs
@@ -1,0 +1,51 @@
+use std::path::{Path, PathBuf};
+
+#[derive(Default)]
+pub struct NavigationHistory {
+    items: Vec<PathBuf>,
+    index: usize,
+}
+
+impl From<&PathBuf> for NavigationHistory {
+    fn from(value: &PathBuf) -> Self {
+        Self {
+            items: vec![value.to_path_buf()],
+            index: 0,
+        }
+    }
+}
+
+impl NavigationHistory {
+    pub fn prev(&mut self) -> Option<&PathBuf> {
+        if self.index == 0 {
+            return None;
+        }
+
+        self.index -= 1;
+        self.items.get(self.index)
+    }
+
+    pub fn next(&mut self) -> Option<&PathBuf> {
+        if self.index == self.items.len() - 1 {
+            return None;
+        }
+
+        self.index += 1;
+        self.items.get(self.index)
+    }
+
+    pub fn push(&mut self, path: &Path) {
+        self.index += 1;
+
+        if self.index < self.items.len() {
+            self.items.truncate(self.index);
+        }
+
+        self.items.push(path.to_path_buf());
+    }
+
+    pub fn remove_current(&mut self) {
+        self.items.remove(self.index);
+        self.items.dedup();
+    }
+}

--- a/src/types/command/impl_appcommand.rs
+++ b/src/types/command/impl_appcommand.rs
@@ -20,6 +20,9 @@ impl AppCommand for Command {
             Self::ParentDirectory => CMD_PARENT_DIRECTORY,
             Self::PreviousDirectory => CMD_PREVIOUS_DIRECTORY,
 
+            Self::HistoryNext => CMD_HISTORY_NEXT,
+            Self::HistoryPrev => CMD_HISTORY_PREV,
+
             Self::NewTab { .. } => CMD_NEW_TAB,
             Self::CloseTab => CMD_CLOSE_TAB,
             Self::CommandLine { .. } => CMD_COMMAND_LINE,

--- a/src/types/command/impl_appexecute.rs
+++ b/src/types/command/impl_appexecute.rs
@@ -30,6 +30,9 @@ impl AppExecute for Command {
             Self::ParentDirectory => change_directory::parent_directory(app_state),
             Self::PreviousDirectory => change_directory::previous_directory(app_state),
 
+            Self::HistoryNext => history::next(app_state),
+            Self::HistoryPrev => history::prev(app_state),
+
             Self::NewTab { mode, last } => tab_ops::new_tab(app_state, mode, *last),
             Self::CloseTab => tab_ops::close_tab(app_state),
             Self::CommandLine { prefix, suffix } => command_line::read_and_execute(

--- a/src/types/command/impl_comment.rs
+++ b/src/types/command/impl_comment.rs
@@ -20,6 +20,9 @@ impl CommandComment for Command {
             Self::ParentDirectory => "CD to parent directory",
             Self::PreviousDirectory => "CD to the last dir in history",
 
+            Self::HistoryNext => "Go forward in navigation history",
+            Self::HistoryPrev => "Go back in navigation history",
+
             Self::NewTab { .. } => "Open a new tab",
             Self::CloseTab => "Close current tab",
             Self::CommandLine { prefix, .. } => match prefix.trim() {

--- a/src/types/command/impl_from_str.rs
+++ b/src/types/command/impl_from_str.rs
@@ -51,6 +51,9 @@ impl std::str::FromStr for Command {
 
         simple_command_conversion_case!(command, CMD_HELP, Self::Help);
 
+        simple_command_conversion_case!(command, CMD_HISTORY_NEXT, Self::HistoryNext);
+        simple_command_conversion_case!(command, CMD_HISTORY_PREV, Self::HistoryPrev);
+
         simple_command_conversion_case!(command, CMD_BOOKMARK_ADD, Self::BookmarkAdd);
         simple_command_conversion_case!(
             command,

--- a/src/types/command/mod.rs
+++ b/src/types/command/mod.rs
@@ -34,6 +34,9 @@ pub enum Command {
     ParentDirectory,
     PreviousDirectory,
 
+    HistoryNext,
+    HistoryPrev,
+
     CommandLine {
         prefix: String,
         suffix: String,


### PR DESCRIPTION
This is a per-tab implementation of navigation history in the style of what ranger and others already have. For the end user there are two new commands: `history_next` and `history_prev` which do exactly what the name says, pretty straightforward.