### PR TITLE
feat: add calculate_cumulative_size command

### DIFF
--- a/config/keymap.toml
+++ b/config/keymap.toml
@@ -79,6 +79,7 @@ keymap = [
 
   { keys = ["delete"], commands = ["delete_files"] },
   { keys = ["d", "D"], commands = ["delete_files"] },
+  { keys = ["d", "c"], commands = ["calculate_cumulative_size"] },
 
   { keys = ["p", "p"], commands = ["paste_files"] },
   { keys = ["p", "o"], commands = ["paste_files --overwrite=true"] },

--- a/src/commands/cumulative_size.rs
+++ b/src/commands/cumulative_size.rs
@@ -1,0 +1,93 @@
+use std::fs;
+use std::path;
+
+use crate::error::AppResult;
+use crate::types::state::AppState;
+use crate::utils::format::file_size_to_string;
+
+/// Recursively compute the total size in bytes of every regular file rooted
+/// at `path`. Symlinks are not followed; their own size is included instead.
+/// I/O errors on individual entries are silently skipped, matching `du`.
+fn compute_size(path: &path::Path) -> u64 {
+    let symlink_meta = match fs::symlink_metadata(path) {
+        Ok(m) => m,
+        Err(_) => return 0,
+    };
+
+    let file_type = symlink_meta.file_type();
+    if file_type.is_symlink() {
+        return symlink_meta.len();
+    }
+    if !file_type.is_dir() {
+        return symlink_meta.len();
+    }
+
+    let read_dir = match fs::read_dir(path) {
+        Ok(rd) => rd,
+        Err(_) => return symlink_meta.len(),
+    };
+
+    let mut total: u64 = 0;
+    for entry in read_dir.flatten() {
+        total = total.saturating_add(compute_size(&entry.path()));
+    }
+    total
+}
+
+pub fn calculate_cumulative_size(app_state: &mut AppState) -> AppResult {
+    let targets: Vec<(path::PathBuf, String)> = match app_state
+        .state
+        .tab_state_ref()
+        .curr_tab_ref()
+        .curr_list_ref()
+    {
+        Some(list) => list
+            .selected_or_current()
+            .into_iter()
+            .map(|e| (e.file_path().to_path_buf(), e.file_name().to_string()))
+            .collect(),
+        None => Vec::new(),
+    };
+
+    if targets.is_empty() {
+        return Ok(());
+    }
+
+    let mut total: u64 = 0;
+    let mut sizes: Vec<(String, u64)> = Vec::with_capacity(targets.len());
+    for (path, name) in &targets {
+        let size = compute_size(path);
+        total = total.saturating_add(size);
+        sizes.push((name.clone(), size));
+    }
+
+    if let Some(list) = app_state
+        .state
+        .tab_state_mut()
+        .curr_tab_mut()
+        .curr_list_mut()
+    {
+        for (name, size) in &sizes {
+            if let Some(entry) = list.iter_mut().find(|e| e.file_name() == name.as_str()) {
+                entry.metadata.update_cumulative_size(*size);
+            }
+        }
+    }
+
+    let msg = if sizes.len() == 1 {
+        format!(
+            "Size of {}: {}",
+            sizes[0].0.trim(),
+            file_size_to_string(total).trim()
+        )
+    } else {
+        format!(
+            "Cumulative size of {} items: {}",
+            sizes.len(),
+            file_size_to_string(total).trim()
+        )
+    };
+    app_state.state.message_queue_mut().push_info(msg);
+
+    Ok(())
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -3,6 +3,7 @@ pub mod bulk_rename;
 pub mod case_sensitivity;
 pub mod change_directory;
 pub mod command_line;
+pub mod cumulative_size;
 pub mod cursor_move;
 pub mod custom_search;
 pub mod delete_files;

--- a/src/constants/command_name.rs
+++ b/src/constants/command_name.rs
@@ -101,4 +101,5 @@ cmd_constants![
     (CMD_CUSTOM_SEARCH, "custom_search"),
     (CMD_CUSTOM_SEARCH_INTERACTIVE, "custom_search_interactive"),
     (CMD_SIGNAL_SUSPEND, "suspend"),
+    (CMD_CALCULATE_CUMULATIVE_SIZE, "calculate_cumulative_size"),
 ];

--- a/src/fs/metadata.rs
+++ b/src/fs/metadata.rs
@@ -47,6 +47,7 @@ pub enum LinkType {
 pub struct JoshutoMetadata {
     pub len: u64,
     pub directory_size: Option<usize>,
+    pub cumulative_size: Option<u64>,
     pub modified: time::SystemTime,
     pub accessed: time::SystemTime,
     pub mode: Mode,
@@ -75,6 +76,7 @@ impl JoshutoMetadata {
         };
 
         let directory_size = None;
+        let cumulative_size = None;
         let (file_type, mode) = match metadata.as_ref() {
             Ok(metadata) => {
                 let metadata_mode = metadata.mode();
@@ -121,6 +123,7 @@ impl JoshutoMetadata {
         Ok(Self {
             len,
             directory_size,
+            cumulative_size,
             modified,
             accessed,
             mode,
@@ -143,6 +146,14 @@ impl JoshutoMetadata {
 
     pub fn update_directory_size(&mut self, size: usize) {
         self.directory_size = Some(size);
+    }
+
+    pub fn cumulative_size(&self) -> Option<u64> {
+        self.cumulative_size
+    }
+
+    pub fn update_cumulative_size(&mut self, size: u64) {
+        self.cumulative_size = Some(size);
     }
 
     pub fn modified(&self) -> time::SystemTime {

--- a/src/history.rs
+++ b/src/history.rs
@@ -65,6 +65,9 @@ pub fn create_dirlist_with_history(
             if let Some(former_entry) = former_entries_by_file_name.get(entry.file_name()) {
                 entry.set_permanent_selected(former_entry.is_permanent_selected());
                 entry.set_visual_mode_selected(former_entry.is_visual_mode_selected());
+                if let Some(size) = former_entry.metadata.cumulative_size() {
+                    entry.metadata.update_cumulative_size(size);
+                }
             }
         }
     }

--- a/src/types/command/impl_appcommand.rs
+++ b/src/types/command/impl_appcommand.rs
@@ -126,6 +126,8 @@ impl AppCommand for Command {
 
             Self::BookmarkAdd => CMD_BOOKMARK_ADD,
             Self::BookmarkChangeDirectory => CMD_BOOKMARK_CHANGE_DIRECTORY,
+
+            Self::CalculateCumulativeSize => CMD_CALCULATE_CUMULATIVE_SIZE,
         }
     }
 }

--- a/src/types/command/impl_appexecute.rs
+++ b/src/types/command/impl_appexecute.rs
@@ -204,6 +204,8 @@ impl AppExecute for Command {
                 bookmark::change_directory_bookmark(app_state, backend)
             }
 
+            Self::CalculateCumulativeSize => cumulative_size::calculate_cumulative_size(app_state),
+
             Self::CustomSearch(words) => {
                 custom_search::custom_search(app_state, backend, words.as_slice(), false)
             }

--- a/src/types/command/impl_comment.rs
+++ b/src/types/command/impl_comment.rs
@@ -141,6 +141,7 @@ impl CommandComment for Command {
 
             Self::BookmarkAdd => "Add a bookmark",
             Self::BookmarkChangeDirectory => "Navigate to a bookmark",
+            Self::CalculateCumulativeSize => "Calculate cumulative size of selected files",
             Self::CustomSearch(_) => "Find file based on the custom command",
             Self::CustomSearchInteractive(_) => {
                 "Interactively find file based on the custom command"

--- a/src/types/command/impl_from_str.rs
+++ b/src/types/command/impl_from_str.rs
@@ -124,6 +124,12 @@ impl std::str::FromStr for Command {
 
         simple_command_conversion_case!(command, CMD_SIGNAL_SUSPEND, Self::SignalSuspend);
 
+        simple_command_conversion_case!(
+            command,
+            CMD_CALCULATE_CUMULATIVE_SIZE,
+            Self::CalculateCumulativeSize
+        );
+
         if command == CMD_QUIT {
             match arg {
                 "--force" => Ok(Self::Quit(QuitAction::Force)),

--- a/src/types/command/mod.rs
+++ b/src/types/command/mod.rs
@@ -213,4 +213,6 @@ pub enum Command {
 
     BookmarkAdd,
     BookmarkChangeDirectory,
+
+    CalculateCumulativeSize,
 }

--- a/src/types/option/sort/sort_option.rs
+++ b/src/types/option/sort/sort_option.rs
@@ -107,7 +107,8 @@ fn mtime_sort(file1: &JoshutoDirEntry, file2: &JoshutoDirEntry) -> cmp::Ordering
 }
 
 fn size_sort(file1: &JoshutoDirEntry, file2: &JoshutoDirEntry) -> cmp::Ordering {
-    file1.metadata.len().cmp(&file2.metadata.len())
+    let size = |e: &JoshutoDirEntry| e.metadata.cumulative_size().unwrap_or(e.metadata.len());
+    size(file1).cmp(&size(file2))
 }
 
 fn ext_sort(file1: &JoshutoDirEntry, file2: &JoshutoDirEntry) -> cmp::Ordering {

--- a/src/ui/widgets/tui_dirlist_detailed.rs
+++ b/src/ui/widgets/tui_dirlist_detailed.rs
@@ -123,6 +123,9 @@ impl Widget for TuiDirListDetailed<'_> {
 }
 
 fn get_entry_size_string(entry: &JoshutoDirEntry) -> String {
+    if let Some(size) = entry.metadata.cumulative_size() {
+        return format::file_size_to_string(size);
+    }
     match entry.metadata.file_type() {
         FileType::Directory => entry
             .metadata


### PR DESCRIPTION
## Summary

[![asciicast](https://asciinema.org/a/qB4xl9ckQwLbV3Uu.svg)](https://asciinema.org/a/qB4xl9ckQwLbV3Uu)

Adds a `calculate_cumulative_size` command that mimics ranger's `dc`
("get cumulative size"). It recursively walks the visual / permanent
selection (falling back to the entry under the cursor when nothing is
selected), sums every regular file's bytes, stores the result on each
measured entry, and posts the total to the status line.

Bound to `d c` by default — matches the ranger muscle memory.

Closes the recurring ask for a `du -hs`-style readout (see #229 and the
discussion under #334, where partial / lazy directory sizing was
rejected for breaking user expectations).

## What's in the PR

### New command

- `src/commands/cumulative_size.rs` — recursive walker (`du`-style:
  does not follow symlinks, counts the symlink's own size; tolerates
  per-entry I/O errors) and the command entry point. Iterates
  `selected_or_current()`, sums, stores per-entry, and emits a status
  message — `Size of foo: 1.2 G` for one entry, `Cumulative size of N
  items: …` for many.

### Metadata

- `src/fs/metadata.rs` — new `cumulative_size: Option<u64>` field,
  distinct from the existing `directory_size: Option<usize>` (which is
  an item count). Accessor + setter, no other call-sites touched.

### Command plumbing

The usual fan-out so the command is reachable from the keymap, the
command line, and the help page:

- `src/constants/command_name.rs` — `CMD_CALCULATE_CUMULATIVE_SIZE`.
- `src/types/command/mod.rs` — `Command::CalculateCumulativeSize`.
- `src/types/command/impl_appcommand.rs`,
  `impl_appexecute.rs`, `impl_from_str.rs`, `impl_comment.rs` — name,
  dispatch, parsing, help text.

### Display

- `src/ui/widgets/tui_dirlist_detailed.rs` — when an entry carries a
  `cumulative_size`, the detailed dirlist renders it through
  `file_size_to_string` (so a measured directory shows e.g. `1.2 G`
  instead of the item count). Entries that have never been measured
  fall back to existing behavior (count for dirs, raw len for files),
  so nothing changes until the user runs the command.

### Sort integration (bug fix in the same PR)

Two follow-ups discovered while testing:

1. **Reload preserved selection state but not the measured size.**
   `sort` triggers a soft reload, which rebuilt entries from disk and
   wiped `cumulative_size`. `src/history.rs` now carries the value
   across reload next to the existing selection-state preservation
   loop, so measurements survive any reload or re-sort.
2. **`size_sort` only compared `metadata.len()`** — directories all
   tied at 0 and the sort order was meaningless for them.
   `src/types/option/sort/sort_option.rs` now falls back to
   `cumulative_size` when present, so directories with measured sizes
   sort correctly against each other and against files.

### Default keybind

- `config/keymap.toml` — `{ keys = ["d", "c"], commands =
  ["calculate_cumulative_size"] }`. The `d, _` chord is already used
  for `cut_files` (`d d`) and `delete_files` (`d D`), so this slots in
  naturally and matches ranger.

## Behavior

| Input                                  | Result                                                                       |
| -------------------------------------- | ---------------------------------------------------------------------------- |
| `d c` on a single directory            | Walks the tree, replaces the count in the size column with `1.2 G`-style.    |
| `d c` with N entries selected          | Measures each; status line shows `Cumulative size of N items: …`.            |
| `d c` on a file                        | Just reports the file's size in the status line.                             |
| `s s` after `d c`                      | Sort by size now respects the measured value (previously dirs all tied).     |
| Navigate away and back / re-sort       | Measurements are preserved (carried across reload via the parent dir list).  |

## Tradeoffs / known limitations

- **Synchronous.** The walker blocks the UI while running. Acceptable
  for the small/medium trees this is usually pointed at; for huge
  trees the natural follow-up is to push the walk onto the existing
  worker thread infrastructure (see `src/types/io/`) and update the
  entry asynchronously. Kept synchronous in v1 to keep the diff
  reviewable; happy to do the async pass in a follow-up PR if
  preferred.
- **No cache.** Re-running `d c` on the same directory re-walks it.
  A path-keyed cache + invalidation on `mtime` change would be a
  natural next step.
- **No cancellation.** No way to abort an in-progress measurement on
  a huge tree. Falls out of the async refactor above.
